### PR TITLE
Fix empty licence column in ListAllAvailableImages (get_instances)

### DIFF
--- a/src/vfbquery/vfb_queries.py
+++ b/src/vfbquery/vfb_queries.py
@@ -2263,7 +2263,7 @@ def get_instances(short_form: str, return_dataframe=True, limit: int = -1):
               (i)-[:has_source]->(ds:DataSet)
         WHERE p.short_form IN {class_ids!r}
         OPTIONAL MATCH (i)-[rx:database_cross_reference]->(site:Site)
-        OPTIONAL MATCH (ds)-[:license|licence]->(lic:License)
+        OPTIONAL MATCH (ds)-[:has_license|license]->(lic:License)
         RETURN i.short_form as id,
                apoc.text.format("[%s](%s)",[i.label,i.short_form]) AS label,
                apoc.text.join(i.uniqueFacets, '|') AS tags,


### PR DESCRIPTION
get_instances matched the dataset licence edge as [:license|licence], but the canonical relationship in the VFB Neo4j graph is has_license. Most DataSets (e.g. Hemibrain Xu2020NeuronsV1.2.1, FAFB Turner_Evans2020) use has_license, so lic bound null and the
REPLACE(..., '[null](null)', '') collapsed the column to an empty string; the British-spelt licence alternate matched nothing.

Align with the other two image/dataset queries in this file (get_all_aligned_images, the dataset query) and vfb_connect's TermInfo, all of which use [:has_license|license].