### PR TITLE
Attach ListAllAvailableImages only to anatomy Class terms

### DIFF
--- a/src/vfbquery/_version.py
+++ b/src/vfbquery/_version.py
@@ -6,4 +6,4 @@ this file, so the packaging metadata, ``vfbquery.__version__`` and the SOLR
 cache's version stamp can never drift apart.
 """
 
-__version__ = "1.22.8"
+__version__ = "1.22.9"

--- a/src/vfbquery/vfb_queries.py
+++ b/src/vfbquery/vfb_queries.py
@@ -820,9 +820,14 @@ def term_info_parse_object(results, short_form):
             if termInfo["IsIndividual"] and techniques:
                 termInfo["Technique"].extend(techniques)
                 termInfo["Technique"] = sorted(list(set(termInfo["Technique"])))
-            # add a query to `queries` list for listing all available images
-            q = ListAllAvailableImages_to_schema(termInfo["Name"], {"short_form":vfbTerm.term.core.short_form})
-            queries.append(q)
+            # add a query for listing all available images -- only for anatomy
+            # Class terms (get_instances expects a Class, per this query's own
+            # Class+Anatomy criteria). DataSets/Individuals that merely have
+            # images must not get it (they use DatasetImages etc.), otherwise a
+            # dataset shows a spurious "List all available images" query.
+            if contains_all_tags(termInfo["SuperTypes"], ["Class", "Anatomy"]):
+                q = ListAllAvailableImages_to_schema(termInfo["Name"], {"short_form":vfbTerm.term.core.short_form})
+                queries.append(q)
 
         # If the term has channel images but not anatomy channel images, create thumbnails from channel images.
         if vfbTerm.channel_image and len(vfbTerm.channel_image) > 0:


### PR DESCRIPTION
Gate `ListAllAvailableImages` (which runs `get_instances` and is declared for `Class+Anatomy`) so it is only attached to anatomy **Class** terms.

It was being added inside the `anatomy_channel_image` block for *any* term with example images, ignoring its own criteria — so DataSets/Individuals with images (e.g. **Otto2020**) got a spurious "List all available images" query alongside the correct `DatasetImages`.

**Verified:** Otto2020 (DataSet) → now only `DatasetImages`; medulla (FBbt_00003748, Class+Anatomy) → still has `ListAllAvailableImages` + the rest.