### PR TITLE
AllAlignedImages: cache the ID index + hydrate paged rows, not a 430M…

### DIFF
--- a/src/vfbquery/cached_functions.py
+++ b/src/vfbquery/cached_functions.py
@@ -79,6 +79,8 @@ from .vfb_queries import (
     get_template_roi_tree as _original_get_template_roi_tree,
     get_dataset_images as _original_get_dataset_images,
     get_all_aligned_images as _original_get_all_aligned_images,
+    get_all_aligned_image_ids as _original_get_all_aligned_image_ids,
+    get_aligned_images_page as _original_get_aligned_images_page,
     get_aligned_datasets as _original_get_aligned_datasets,
     get_all_datasets as _original_get_all_datasets,
     get_terms_for_pub as _original_get_terms_for_pub,
@@ -379,20 +381,33 @@ def get_dataset_images_cached(dataset_short_form: str, return_dataframe=True, li
     """
     return _original_get_dataset_images(dataset_short_form=dataset_short_form, return_dataframe=return_dataframe, limit=limit)
 
-@with_solr_cache('all_aligned_images')
-def get_all_aligned_images_cached(template_short_form: str, return_dataframe=True, limit: int = -1, force_refresh: bool = False):
-    """
-    Enhanced get_all_aligned_images with SOLR caching.
+@with_solr_cache('all_aligned_image_ids')
+def _get_all_aligned_image_ids_cached(template_short_form: str, force_refresh: bool = False):
+    """Cache only the small ordered ID-list index for AllAlignedImages, keyed by
+    template. Pages hydrate from this list without recomputing the expensive
+    whole-template traversal, and without ever caching the large row payload."""
+    return _original_get_all_aligned_image_ids(template_short_form)
 
-    Args:
-        template_short_form: Template short form
-        return_dataframe: Whether to return DataFrame or list of dicts
-        limit: Maximum number of results (-1 for all)
 
-    Returns:
-        All aligned images data
+def get_all_aligned_images_cached(template_short_form: str, return_dataframe=True, limit: int = -1, offset: int = 0, force_refresh: bool = False):
+    """AllAlignedImages via the cached ID-list index + on-demand page hydration.
+
+    Only the ID list is cached (small); each page (<=10000 rows, id ASC) is
+    hydrated on demand, so the multi-hundred-MB full row payload is never cached
+    or serialised in one go. A single page covers everything when count <= 10000;
+    the client pages by ``offset`` only when the returned ``count`` > 10000.
     """
-    return _original_get_all_aligned_images(template_short_form=template_short_form, return_dataframe=return_dataframe, limit=limit)
+    from .vfb_queries import ALL_ALIGNED_IMAGES_MAX_PAGE
+    if limit is None or limit <= 0 or limit > ALL_ALIGNED_IMAGES_MAX_PAGE:
+        limit = ALL_ALIGNED_IMAGES_MAX_PAGE
+    if offset is None or offset < 0:
+        offset = 0
+    ids = _get_all_aligned_image_ids_cached(template_short_form, force_refresh=force_refresh)
+    page_ids = ids[offset:offset + limit]
+    return _original_get_aligned_images_page(
+        template_short_form, page_ids, len(ids),
+        offset=offset, limit=limit, return_dataframe=return_dataframe,
+    )
 
 @with_solr_cache('aligned_datasets')
 def get_aligned_datasets_cached(template_short_form: str, return_dataframe=True, limit: int = -1, force_refresh: bool = False):

--- a/src/vfbquery/ha_api.py
+++ b/src/vfbquery/ha_api.py
@@ -392,7 +392,7 @@ def _run_term_info(short_form, force_refresh=False):
     return _convert_numpy_types(result)
 
 
-def _run_query(short_form, func_name, force_refresh=False):
+def _run_query(short_form, func_name, force_refresh=False, offset=0, limit=0):
     """Execute a named query function in a worker process. Returns JSON-serialisable dict.
 
     ``force_refresh`` is propagated to the underlying ``vfb_queries`` function
@@ -402,6 +402,9 @@ def _run_query(short_form, func_name, force_refresh=False):
     """
     fn = getattr(_vfb, func_name)
     base_kwargs = {"return_dataframe": False}
+    if func_name in PAGED_QUERY_FUNCS:
+        base_kwargs["offset"] = offset
+        base_kwargs["limit"] = limit if (limit and limit > 0) else -1
 
     # Defensive force_refresh forwarding.
     #
@@ -698,6 +701,10 @@ async def handle_get_term_info(request):
         await tracker.finish_work()
 
 
+# Query functions that accept offset/limit paging (id ASC pages, <=10000 rows).
+PAGED_QUERY_FUNCS = {"get_all_aligned_images"}
+
+
 async def handle_run_query(request):
     """GET /run_query?id=<short_form>&query_type=<QueryType>&include_graph=false"""
     short_form = request.query.get("id")
@@ -727,11 +734,22 @@ async def handle_run_query(request):
 
     rcache = request.app["result_cache"]
     coalescer = request.app["coalescer"]
+    # Paging params — only consumed by PAGED_QUERY_FUNCS; harmless otherwise.
+    def _int_param(name, default):
+        try:
+            return int(request.query.get(name, default))
+        except (TypeError, ValueError):
+            return default
+    offset = max(0, _int_param("offset", 0))
+    limit = _int_param("limit", 0)  # 0/absent -> function default page size
+
     # Normalize key — AllDatasets ignores the id parameter
     if func_name == "get_all_datasets":
         key = "run_query::AllDatasets"
     else:
         key = f"run_query:{short_form}:{query_type}"
+    if func_name in PAGED_QUERY_FUNCS:
+        key = f"{key}:{offset}:{limit}"
 
     # ---- L1: in-memory result cache ----
     # force_refresh=true skips the cache read AND drops any stale entry so
@@ -800,7 +818,7 @@ async def handle_run_query(request):
             await tracker.leave_queue_start_work()
             loop = asyncio.get_event_loop()
             result = await loop.run_in_executor(
-                pool, _run_query, short_form, func_name, force_refresh
+                pool, _run_query, short_form, func_name, force_refresh, offset, limit
             )
         log.info("run_query id=%s query_type=%s — done", short_form, query_type)
         rcache.put(key, result)

--- a/src/vfbquery/vfb_queries.py
+++ b/src/vfbquery/vfb_queries.py
@@ -6062,30 +6062,89 @@ def get_dataset_images(dataset_short_form: str, return_dataframe=True, limit: in
     return {"headers": {"id": {"title": "ID", "type": "selection_id", "order": -1}, "name": {"title": "Image", "type": "markdown", "order": 0}, "tags": {"title": "Tags", "type": "tags", "order": 1}, "type": {"title": "Type", "type": "text", "order": 2}, "template": {"title": "Template", "type": "markdown", "order": 3}, "technique": {"title": "Imaging Technique", "type": "text", "order": 4}, "thumbnail": {"title": "Thumbnail", "type": "markdown", "order": 9}}, "rows": [{key: row[key] for key in ["id", "name", "tags", "type", "template", "technique", "thumbnail"]} for row in safe_to_dict(df, sort_by_id=False)], "count": total_count}
 
 
-def get_all_aligned_images(template_short_form: str, return_dataframe=True, limit: int = -1):
-    """List all images aligned to a template."""
-    count_query = f"MATCH (:Template {{short_form:'{template_short_form}'}})<-[:depicts]-(:Template)<-[:in_register_with]-(:Individual)-[:depicts]->(di:Individual) RETURN count(di) AS count"
-    count_results = vc.nc.commit_list([count_query])
-    total_count = get_dict_cursor()(count_results)[0]['count'] if count_results else 0
+ALL_ALIGNED_IMAGES_MAX_PAGE = 10000
+_ALL_ALIGNED_IMAGES_HEADERS = {
+    "id": {"title": "ID", "type": "selection_id", "order": -1},
+    "name": {"title": "Image", "type": "markdown", "order": 0},
+    "tags": {"title": "Tags", "type": "tags", "order": 1},
+    "type": {"title": "Type", "type": "markdown", "order": 2},
+    "template": {"title": "Template", "type": "markdown", "order": 3},
+    "technique": {"title": "Imaging Technique", "type": "text", "order": 4},
+    "thumbnail": {"title": "Thumbnail", "type": "markdown", "order": 9},
+}
 
-    main_query = f"""MATCH (templ:Template:Individual {{short_form:'{template_short_form}'}})<-[:depicts]-(:Template:Individual)<-[irw:in_register_with]-(channel:Individual)-[:depicts]->(di:Individual)
+
+def get_all_aligned_image_ids(template_short_form: str):
+    """Ordered (id ASC) list of the distinct anatomical individuals aligned to a
+    template. This whole-template traversal is the expensive part; caching just
+    this small list (see cached_functions) lets each page hydrate fast. The
+    ``id ASC`` order is deterministic so a cached index and every offset page are
+    reproducible within a cache generation."""
+    q = (f"MATCH (:Template:Individual {{short_form:'{template_short_form}'}})"
+         "<-[:depicts]-(:Template:Individual)<-[:in_register_with]-(:Individual)"
+         "-[:depicts]->(di:Individual) RETURN DISTINCT di.short_form AS id ORDER BY id ASC")
+    results = vc.nc.commit_list([q])
+    rows = get_dict_cursor()(results) if results else []
+    return [r['id'] for r in rows]
+
+
+def get_aligned_images_page(template_short_form: str, page_ids, total_count, offset=0, limit=ALL_ALIGNED_IMAGES_MAX_PAGE, return_dataframe=True):
+    """Hydrate one page of AllAlignedImages rows.
+
+    One row per anatomical individual; every column that can be multi-valued is
+    returned as an appropriately formatted list. In particular ``thumbnail`` is
+    the ' | '-joined list of ALL of that individual's aligned images (the same
+    individual aligned to different templates) — the frontend orders the loaded
+    template's variant first. Rows are ordered by id ASC to match the cached
+    index page."""
+    if not page_ids:
+        empty = {"headers": _ALL_ALIGNED_IMAGES_HEADERS, "rows": [], "count": total_count, "offset": offset, "limit": limit}
+        return pd.DataFrame(columns=list(_ALL_ALIGNED_IMAGES_HEADERS.keys())) if return_dataframe else empty
+
+    hydrate_query = f"""MATCH (di:Individual) WHERE di.short_form IN {list(page_ids)!r}
+        OPTIONAL MATCH (di)<-[:depicts]-(ch:Individual)-[irw:in_register_with]->(:Template:Individual)-[:depicts]->(templ:Template:Individual)
         OPTIONAL MATCH (di)-[:INSTANCEOF]->(typ:Class)
-        OPTIONAL MATCH (channel)-[:is_specified_output_of]->(technique:Class)
-        RETURN DISTINCT di.short_form AS id,
+        OPTIONAL MATCH (ch)-[:is_specified_output_of]->(technique:Class)
+        WITH di,
+             collect(DISTINCT REPLACE(apoc.text.format("[%s](%s)",[CASE WHEN templ.symbol[0] <> '' THEN templ.symbol[0] ELSE templ.label END, templ.short_form]), '[null](null)', '')) AS templates,
+             collect(DISTINCT REPLACE(apoc.text.format("[![%s](%s '%s')](%s)",[di.label + " aligned to " + CASE WHEN templ.symbol[0] <> '' THEN templ.symbol[0] ELSE templ.label END, REPLACE(COALESCE(irw.thumbnail[0],""),"thumbnailT.png","thumbnail.png"), di.label + " aligned to " + CASE WHEN templ.symbol[0] <> '' THEN templ.symbol[0] ELSE templ.label END, templ.short_form + "," + di.short_form]), "[![null]( 'null')](null)", "")) AS thumbnails,
+             collect(DISTINCT REPLACE(apoc.text.format("[%s](%s)",[typ.label,typ.short_form]), '[null](null)', '')) AS types,
+             collect(DISTINCT technique.label) AS techniques
+        RETURN di.short_form AS id,
                '[' + di.label + ']({VFB_REPORT_BASE}' + di.short_form + ')' AS name,
                apoc.text.join(coalesce(di.uniqueFacets, []), '|') AS tags,
-               REPLACE(apoc.text.format("[%s](%s)",[typ.label,typ.short_form]), '[null](null)', '') AS type,
-               REPLACE(apoc.text.format("[%s](%s)",[CASE WHEN templ.symbol[0] <> '' THEN templ.symbol[0] ELSE templ.label END,templ.short_form]), '[null](null)', '') AS template,
-               technique.label AS technique,
-               REPLACE(apoc.text.format("[![%s](%s '%s')](%s)",[di.label + " aligned to " + CASE WHEN templ.symbol[0] <> '' THEN templ.symbol[0] ELSE templ.label END, REPLACE(COALESCE(irw.thumbnail[0],""),"thumbnailT.png","thumbnail.png"), di.label + " aligned to " + CASE WHEN templ.symbol[0] <> '' THEN templ.symbol[0] ELSE templ.label END, templ.short_form + "," + di.short_form]), "[![null]( 'null')](null)", "") AS thumbnail"""
-    if limit != -1: main_query += f" LIMIT {limit}"
+               apoc.text.join([x IN types WHERE x <> ''], ' | ') AS type,
+               apoc.text.join([x IN templates WHERE x <> ''], ' | ') AS template,
+               apoc.text.join([x IN techniques WHERE x IS NOT NULL], ', ') AS technique,
+               apoc.text.join([x IN thumbnails WHERE x <> ''], ' | ') AS thumbnail"""
 
-    results = vc.nc.commit_list([main_query])
+    results = vc.nc.commit_list([hydrate_query])
     df = pd.DataFrame.from_records(get_dict_cursor()(results))
-    if not df.empty: df = encode_markdown_links(df, ['name', 'template', 'thumbnail'])
+    if not df.empty:
+        df = encode_markdown_links(df, ['name', 'template', 'thumbnail'])
+        df = df.sort_values('id').reset_index(drop=True)
 
-    if return_dataframe: return df
-    return {"headers": {"id": {"title": "ID", "type": "selection_id", "order": -1}, "name": {"title": "Image", "type": "markdown", "order": 0}, "tags": {"title": "Tags", "type": "tags", "order": 1}, "type": {"title": "Type", "type": "text", "order": 2}, "template": {"title": "Template", "type": "markdown", "order": 3}, "technique": {"title": "Imaging Technique", "type": "text", "order": 4}, "thumbnail": {"title": "Thumbnail", "type": "markdown", "order": 9}}, "rows": [{key: row[key] for key in ["id", "name", "tags", "type", "template", "technique", "thumbnail"]} for row in safe_to_dict(df, sort_by_id=False)], "count": total_count}
+    if return_dataframe:
+        return df
+    rows = [{key: row[key] for key in ["id", "name", "tags", "type", "template", "technique", "thumbnail"]} for row in safe_to_dict(df, sort_by_id=False)]
+    return {"headers": _ALL_ALIGNED_IMAGES_HEADERS, "rows": rows, "count": total_count, "offset": offset, "limit": limit}
+
+
+def get_all_aligned_images(template_short_form: str, return_dataframe=True, limit: int = ALL_ALIGNED_IMAGES_MAX_PAGE, offset: int = 0):
+    """Images aligned to a template, one row per anatomical individual, paged.
+
+    ``limit`` is capped at 10000 (ALL_ALIGNED_IMAGES_MAX_PAGE); a single response
+    covers everything when the total ``count`` <= 10000, so the client only pages
+    when count > 10000. Rows are ordered by id ASC. This raw path recomputes the
+    id list each call; the cached path (get_all_aligned_images_cached) caches the
+    id list and reuses it across pages."""
+    if limit is None or limit <= 0 or limit > ALL_ALIGNED_IMAGES_MAX_PAGE:
+        limit = ALL_ALIGNED_IMAGES_MAX_PAGE
+    if offset is None or offset < 0:
+        offset = 0
+    ids = get_all_aligned_image_ids(template_short_form)
+    page_ids = ids[offset:offset + limit]
+    return get_aligned_images_page(template_short_form, page_ids, len(ids), offset=offset, limit=limit, return_dataframe=return_dataframe)
 
 
 def _dataset_enrichment_cypher(ds_var: str = "ds") -> str:


### PR DESCRIPTION
…B blob

Rework AllAlignedImages so a template load returns a bounded, sensible-time result instead of the whole corpus:

- vfb_queries: split into get_all_aligned_image_ids (ordered id-list index, ORDER BY di.short_form ASC) + get_aligned_images_page (hydrate one page). Rows are now one-per-anatomical-individual (count = count(DISTINCT di), collapsing the old per-alignment fan-out), and every multi-valued column (thumbnail, type, template, technique) is returned as a ' | '-joined list — the individual's full set of aligned images across templates. Frontend orders the loaded template's variant first.
- cached_functions: cache only the small ID-list index (all_aligned_image_ids); hydrate each <=10000-row page on demand. The multi-hundred-MB row payload is never cached or serialised in one go.
- ha_api: thread offset/limit through handle_run_query and _run_query for paged query types; page size capped at 10000 and folded into the cache key. A single response covers everything when count<=10000; the client pages by offset only when count>10000.

Validated read-only against pdb: JRC2018U count(DISTINCT di)=528678, rows carry per-template thumbnail lists, id ASC order.