### PR TITLE
SimilarMorphologyTo: gate the term-info menu on NBLAST too

### DIFF
--- a/src/vfbquery/_version.py
+++ b/src/vfbquery/_version.py
@@ -6,4 +6,4 @@ this file, so the packaging metadata, ``vfbquery.__version__`` and the SOLR
 cache's version stamp can never drift apart.
 """
 
-__version__ = "1.22.25"
+__version__ = "1.22.26"

--- a/src/vfbquery/vfb_queries.py
+++ b/src/vfbquery/vfb_queries.py
@@ -1032,7 +1032,11 @@ def term_info_parse_object(results, short_form):
             q = TargetNeurons_to_schema(termInfo["Name"], {"short_form": vfbTerm.term.core.short_form})
             queries.append(q)
 
-        if contains_all_tags(termInfo["SuperTypes"], ["Individual", "Neuron"]):
+        # Require the NBLAST facet: SimilarMorphologyTo is backed by
+        # has_similar_morphology_to edges carrying an NBLAST_score, which only
+        # NBLAST-tagged neurons have. Without it the query was attached to every
+        # individual neuron's menu (incl. MaleCNS/BANC) and returned 0 rows.
+        if contains_all_tags(termInfo["SuperTypes"], ["Individual", "Neuron", "NBLAST"]):
             q = SimilarMorphologyTo_to_schema(termInfo["Name"], {"neuron": vfbTerm.term.core.short_form, "similarity_score": "NBLAST_score"})
             queries.append(q)
         # NeuronInputsTo is gated behind the extra "Demo" tag so it does NOT


### PR DESCRIPTION
1.22.25 tightened the query's takes field but the term-info menu attaches the query via a separate contains_all_tags(SuperTypes, [Individual, Neuron]) check, so it still appeared on neurons with no NBLAST data (e.g. MaleCNS VFB_jrmc3kik) and returned 0 rows. Add NBLAST to that check. Bump 1.22.26.