### PR TITLE
RelatedTools: drop find_stocks/find_combo_publications entries (tools…

### DIFF
--- a/src/vfbquery/_version.py
+++ b/src/vfbquery/_version.py
@@ -6,4 +6,4 @@ this file, so the packaging metadata, ``vfbquery.__version__`` and the SOLR
 cache's version stamp can never drift apart.
 """
 
-__version__ = "1.22.27"
+__version__ = "1.22.28"

--- a/src/vfbquery/vfb_queries.py
+++ b/src/vfbquery/vfb_queries.py
@@ -1317,27 +1317,15 @@ def term_info_parse_object(results, short_form):
         if sf.startswith(("FBgn", "FBal", "FBti", "FBtp", "FBco", "FBst")):
             q = FindStocks_to_schema(termInfo["Name"], {"short_form": sf})
             queries.append(q)
-            # Also surface the dedicated find_stocks MCP tool, which exposes
-            # the optional collection_filter parameter (Bloomington, Kyoto,
-            # VDRC, etc.) that the run_query/FindStocks path does not.
-            termInfo["RelatedTools"].append({
-                "tool": "find_stocks",
-                "label": f"Find fly stocks for {termInfo['Name']} (with optional stock-centre filter)",
-                "default_args": {"feature_id": sf},
-            })
+            # FindStocks is offered as a run_query query_type above (in Queries);
+            # the dedicated find_stocks MCP tool was retired, so no RelatedTools entry.
 
         # FlyBase combination publications — for FBco terms
         if sf.startswith("FBco"):
             q = FindComboPublications_to_schema(termInfo["Name"], {"short_form": sf})
             queries.append(q)
-            # Also surface the dedicated find_combo_publications MCP tool,
-            # which returns full per-publication metadata (DOI, PMID, miniref,
-            # year) ready for citation rendering.
-            termInfo["RelatedTools"].append({
-                "tool": "find_combo_publications",
-                "label": f"Find publications for {termInfo['Name']} (with full citation metadata)",
-                "default_args": {"fbco_id": sf},
-            })
+            # FindComboPublications is offered as a run_query query_type above;
+            # the dedicated find_combo_publications MCP tool was retired.
 
         # Bring the parent class's query menu down onto selected Individual
         # instances, reproducing the legacy term-info builder


### PR DESCRIPTION
## Summary

Companion to VFB3-MCP #4, which removes the `find_stocks` and `find_combo_publications` MCP tools (they duplicate the `FindStocks` / `FindComboPublications` `run_query` query_types).

`get_term_info`'s `RelatedTools` array still emitted entries pointing at those two tools, so after they're removed the server would be advertising tools that no longer exist. This drops those two `RelatedTools` entries.

- `FindStocks` / `FindComboPublications` remain in the `Queries` array, so the capability is unchanged via `run_query`.
- `get_hierarchy` RelatedTools entries are untouched (that tool stays).
- Version bump 1.22.27 → 1.22.28.

**Ship together with VFB3-MCP #4.**