### PR TITLE
Fix: templates with no painted domains resolve to null (VFB_00050000)

### DIFF
--- a/src/test/test_template_no_painted_domains.py
+++ b/src/test/test_template_no_painted_domains.py
@@ -1,0 +1,61 @@
+"""
+Regression test for get_term_info on templates that have NO painted anatomical
+domains.
+
+VFB_00050000 (L1 larval CNS ssTEM - Cardona/Janelia, the "Seymour" L1EM larval
+template) carries a single *empty* template_domain from the pipeline
+(index: [], null anatomical_individual). The term_info parser used to do
+``int(image.index[0])`` on every domain unconditionally, so the empty index
+list raised ``IndexError: list index out of range``. That exception propagated
+to get_term_info's ``except IndexError`` handler, which mis-reported it as a
+SOLR access failure ("Error accessing SOLR server!") and returned ``None`` —
+i.e. the endpoint served ``null`` for a perfectly valid, indexed template.
+
+This test asserts the template resolves to a real term-info object with the
+degenerate domain skipped rather than crashing the whole lookup.
+"""
+
+import os
+import unittest
+import sys
+
+# Add src directory to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from vfbquery.vfb_queries import get_term_info
+
+
+class TemplateNoPaintedDomainsTest(unittest.TestCase):
+    """A template with no painted domains must still resolve, not return null."""
+
+    NO_DOMAIN_TEMPLATE = 'VFB_00050000'  # L1EM larval template ("Seymour")
+
+    def setUp(self):
+        # Force the live, synchronous parse path (bypass the two-phase preview
+        # warm and the shared production cache) so the fix is actually exercised.
+        self._prev_cache = os.environ.get('VFBQUERY_CACHE_ENABLED')
+        os.environ['VFBQUERY_CACHE_ENABLED'] = 'false'
+
+    def tearDown(self):
+        if self._prev_cache is None:
+            os.environ.pop('VFBQUERY_CACHE_ENABLED', None)
+        else:
+            os.environ['VFBQUERY_CACHE_ENABLED'] = self._prev_cache
+
+    def test_template_without_painted_domains_resolves(self):
+        result = get_term_info(self.NO_DOMAIN_TEMPLATE)
+        # The regression: this used to be None (-> null over HTTP).
+        self.assertIsNotNone(
+            result,
+            f"get_term_info('{self.NO_DOMAIN_TEMPLATE}') returned None; the empty "
+            f"template_domain must be skipped, not crash the whole lookup."
+        )
+        self.assertEqual(result.get('Id'), self.NO_DOMAIN_TEMPLATE)
+        self.assertTrue(result.get('IsTemplate'), "Template flag should be set")
+        # An empty/degenerate domain must be dropped, never emitted with a bogus index.
+        for idx in (result.get('Domains') or {}):
+            self.assertIsNotNone(idx)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/vfbquery/vfb_queries.py
+++ b/src/vfbquery/vfb_queries.py
@@ -997,6 +997,16 @@ def term_info_parse_object(results, short_form):
                 images = {}
                 termInfo["IsTemplate"] = True
                 for image in vfbTerm.template_domains:
+                    # Skip degenerate/placeholder domains. Templates that carry no
+                    # painted anatomical domains (e.g. VFB_00050000, the L1EM larval
+                    # template) still emit a single empty domain from the pipeline
+                    # (index: [], null anatomical_individual). Without this guard the
+                    # int(image.index[0]) below raised IndexError, which propagated to
+                    # get_term_info's `except IndexError` and was mis-reported as a SOLR
+                    # access failure, returning null for the whole term. Mirrors the
+                    # `if len(image.index) > 0` guard already used for template_channel.
+                    if not image.index or len(image.index) == 0:
+                        continue
                     record = {}
                     record["id"] = image.anatomical_individual.short_form
                     label = image.anatomical_individual.label


### PR DESCRIPTION
## Problem

`get_term_info?id=VFB_00050000` resolves to `null` (HTTP 200), even though the term is a valid, indexed template — **L1 larval CNS ssTEM - Cardona/Janelia** ("Seymour"), the L1EM larval template.

The server log blames SOLR:

```
Finished '.../solr/vfb_json/select/?q=id%3AVFB_00050000&wt=json' ... status 200
No results found for ID 'VFB_00050000'
Error details: list index out of range
Error accessing SOLR server!
```

…but SOLR is fine. `q=id:VFB_00050000` on `vfb_json` returns `numFound=1` with a well-formed `term_info`. The doc is found; **parsing crashes**.

## Root cause

`term_info_parse_object` iterates `template_domains` and runs `int(image.index[0])` on every entry unconditionally (`vfb_queries.py`). Templates with **no painted anatomical domains** still emit a single *empty* domain from the pipeline (`index: []`, null `anatomical_individual`, empty `center`). `image.index[0]` on the empty list raises `IndexError: list index out of range`.

That exception propagates to `get_term_info`'s broad `except IndexError`, which mis-reports it as "Error accessing SOLR server!" and returns `None` → the endpoint serves `null` for the whole term.

Adult templates (e.g. `VFB_00101567` JRC2018Unisex, 47 domains) were unaffected because their domains are all well-formed — which is why only this larval template fails.

Note: the parallel `template_channel` block just above already guards this exact pattern with `if len(image.index) > 0`; the guard was simply never copied to the `template_domains` loop.

## Fix

Skip degenerate/empty domains in the `template_domains` loop, mirroring the existing `template_channel` guard. One targeted change plus a live regression test.

## Verification

- **Before (unpatched HEAD):** `get_term_info('VFB_00050000')` → `None`, reproducing the exact log (`list index out of range` → "Error accessing SOLR server!").
- **After:** resolves with `IsTemplate: True`, `Id: VFB_00050000`, the empty domain dropped (`Domains: 0`), template image retained.
- **No regression:** `VFB_00101567` still parses with all 47 painted domains.
- New test `src/test/test_template_no_painted_domains.py` passes (runs live with `VFBQUERY_CACHE_ENABLED=false` to force the synchronous parse path).

## Follow-up (not in this PR)

The `except IndexError` in `get_term_info` masks any parse-time `IndexError` as a SOLR access error, which is what made this hard to diagnose. Worth narrowing it (or logging a traceback) so future parse bugs surface honestly. Separately, the pipeline could emit `template_domains: []` rather than a single empty placeholder domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
