### PR TITLE
Close the silent no-ops: parameter warnings, exclude_dbs validation, compute budget

### DIFF
--- a/CACHING.md
+++ b/CACHING.md
@@ -257,6 +257,22 @@ separate collection with `VFBQUERY_SOLR_URL` instead.
 | `VFBQUERY_MAX_RESULT_MB` | 100 | Refuse to cache a payload larger than this. |
 | `VFBQUERY_FACET_VOCAB_TTL` | 3600 | How long `/facets` and the type-name validator hold the vocabulary. |
 | `VFBQUERY_PREVIEW_WARM_COOLDOWN` | 300 | How long before re-warming a term whose previews came back incomplete. |
+| `VFBQUERY_COMPUTE_BUDGET` | 180 | How long an HTTP handler waits for a computation before answering `503 status:"computing"`. The computation is **not** cancelled — it keeps running and writes to the cache, so the retry the 503 asks for is the cheap one. Set to `0` to wait indefinitely (the pre-1.22.36 behaviour, minus the cancellation). |
+
+### The compute budget and the cache
+
+`VFBQUERY_COMPUTE_BUDGET` is a caching setting more than a timeout one, which is why it is documented
+here. Before 1.22.36 the worker ran inline in the request coroutine, so anything that cancelled the
+request — a client hanging up, a proxy giving up, a handler timing out — killed the computation
+mid-flight with nothing written to the cache. The next caller started the same minutes-long query from
+scratch, and so did the one after that; a query slow enough to lose one client was a query that could
+never finish for anybody. Every request coalesced onto the same key was woken with "Request aborted,
+please retry" and pointed back at exactly that query.
+
+The computation now runs as a detached task that owns the coalescing future and the cache write, and
+the handler keeps only the *waiting*, which is the part that should be cancellable. So the budget
+bounds how long a caller waits, not how long the work runs, and the first slow request is what warms
+the entry for everyone behind it.
 
 ## Performance Benefits
 

--- a/CACHING.md
+++ b/CACHING.md
@@ -244,9 +244,87 @@ after a release bumps it. There's no dedicated release-triggered warm.
 
 Caveat: a PR that bumps the **minor/major** version reads cold in read-only mode
 (its version's entries don't exist yet — see version invalidation below);
-same-version PRs read the already-warm production entries. If you'd rather PR
-checks read *and* write a cache without touching production, point them at a
-separate collection with `VFBQUERY_SOLR_URL` instead.
+same-version PRs read the already-warm production entries.
+
+Read-only mode's limitation is that it is read-only. A branch that *changes what
+a query returns* can never observe its own results warm, so those steps run with
+`VFBQUERY_CACHE_ENABLED=false` and pay the full cold cost on every job. Cache
+namespaces (next section) exist for that case.
+
+#### Private cache namespaces
+
+```bash
+export VFBQUERY_CACHE_NAMESPACE=ci-my-branch
+export VFBQUERY_CACHE_NAMESPACE_FALLBACK=true   # optional
+```
+
+A namespace moves **every** read, write and delete this process performs into a
+private id prefix. Cache document ids go from
+
+```
+vfb_query_term_info_FBbt_00003748
+ns_ci_my_branch__vfb_query_term_info_FBbt_00003748
+```
+
+so a namespaced process is not merely forbidden from touching production
+entries, it is *incapable of addressing them* — there is no id it can construct
+that names one. That is a stronger guarantee than read-only mode, and it is what
+makes it safe to let experimental code write.
+
+The isolation runs both ways. The production sweep and stats report query
+`id:vfb_query_*`, which does not match `ns_…` ids, and a namespaced sweep queries
+`id:ns_<ns>__vfb_query_*`, which does not match production ids. Neither sees the
+other's documents.
+
+**Why a prefix and not a separate Solr collection.** A collection would need
+provisioning, credentials and its own capacity planning for something that lives
+for the length of a branch. A prefix needs one environment variable, and — the
+part a separate collection cannot do — it can fall back.
+
+**Read-through fallback.** With `VFBQUERY_CACHE_NAMESPACE_FALLBACK=true`, a
+namespace miss is retried against the production document, strictly read-only:
+the fallback path never writes, never purges and never expires what it reads,
+even if it finds the entry corrupt or stale. A brand-new namespace is therefore
+warm on its *first* run rather than after its first run.
+
+Turn fallback **on** for timing work, where a production entry is a fair stand-in
+for what the branch would have computed. Leave it **off** for anything asserting
+on result *content*, where reading production would hide the branch's own
+behaviour behind an entry some other code wrote.
+
+**Naming.** The value is lowercased and everything outside `[a-z0-9]` becomes
+`_`, capped at 48 characters, because the id is interpolated unescaped into a
+Solr `q=id:` term where `-`, `:` and whitespace would change the query's meaning.
+Passing a raw branch name is safe: `fix/silent-noop` becomes `fix_silent_noop`.
+Use one namespace per branch — sharing one between branches reintroduces exactly
+the cross-contamination the namespace is there to prevent.
+
+**Lifetime.** Namespaced entries default to a **48-hour** TTL rather than
+production's 2160 hours (override with `VFBQUERY_CACHE_TTL_HOURS`), so an
+abandoned branch's scratch entries evaporate on their own. To reclaim the space
+immediately:
+
+```python
+from vfbquery.solr_result_cache import get_solr_cache
+get_solr_cache().purge_namespace()
+```
+
+`purge_namespace()` refuses to run when no namespace is set, and refuses an
+explicit empty one: without that guard its delete query would expand to
+`id:vfb_query_*` and wipe the production cache — the precise accident this
+mechanism exists to make impossible.
+
+**Interaction with the other two switches.** `VFBQUERY_CACHE_ENABLED=false` wins
+over everything (the cache layer is bypassed entirely; no server contact at all).
+`VFBQUERY_CACHE_READONLY=true` still suppresses all writes, so setting it
+alongside a namespace gives you a namespace you can only read — rarely what you
+want. Pick one: read-only for "warm production timings, touch nothing", a
+namespace for "write freely, in a sandbox".
+
+A namespace is announced with a `WARNING` at cache construction, naming the
+prefix, whether fallback is on, and the TTL. Set one by accident on a production
+deploy and every lookup misses; the warning is there so the logs say why rather
+than leaving you to infer a total cache wipe.
 
 #### Other environment variables
 
@@ -257,6 +335,9 @@ separate collection with `VFBQUERY_SOLR_URL` instead.
 | `VFBQUERY_MAX_RESULT_MB` | 100 | Refuse to cache a payload larger than this. |
 | `VFBQUERY_FACET_VOCAB_TTL` | 3600 | How long `/facets` and the type-name validator hold the vocabulary. |
 | `VFBQUERY_PREVIEW_WARM_COOLDOWN` | 300 | How long before re-warming a term whose previews came back incomplete. |
+| `VFBQUERY_CACHE_NAMESPACE` | *(empty = production)* | Move all cache reads/writes/deletes into a private id prefix. |
+| `VFBQUERY_CACHE_NAMESPACE_FALLBACK` | `false` | On a namespace miss, read (never write) the production entry. |
+| `VFBQUERY_CACHE_TTL_HOURS` | 2160 (48 when namespaced) | Lifetime of entries written by this process. |
 
 ## Performance Benefits
 

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,12 +1,16 @@
 # Parked GitHub Actions workflows
 
-The two YAML files in this directory are **not running**. They are complete, valid workflow
+The YAML files in this directory are **not running**. They are complete, valid workflow
 definitions sitting one `git mv` away from being active:
 
 ```bash
-git mv docs/ci/search-gates.yml .github/workflows/search-gates.yml
-git mv docs/ci/docs.yml         .github/workflows/docs.yml
+git mv docs/ci/search-gates.yml     .github/workflows/search-gates.yml
+git mv docs/ci/docs.yml             .github/workflows/docs.yml
+git mv docs/ci/performance-test.yml .github/workflows/performance-test.yml
 ```
+
+The last of those **overwrites a workflow that is already running**; check `git diff` after the move
+rather than assuming it is additive.
 
 They are parked rather than committed in place because the credential this branch was pushed with has
 no `workflow` scope, and GitHub rejects a push touching `.github/workflows/` **wholesale** — not just
@@ -31,3 +35,31 @@ The five gates from `scripts/check_gates.sh`, split into three jobs:
 Builds the Sphinx site with `-W`, so a broken cross-reference fails the pull request rather than
 appearing as a red badge on Read the Docs after the merge. A weekly `linkcheck` job runs separately;
 see the comments at the top of the file for why it is not part of the gate.
+
+## `performance-test.yml`
+
+A replacement for the live `.github/workflows/performance-test.yml`, changing only the three `env:`
+blocks so the job uses a private cache namespace on pull requests (see the *Private cache namespaces*
+section of `CACHING.md`). Nothing else in the workflow moves — same steps, same thresholds, same
+report.
+
+What changes, per step:
+
+| Step | Before | After (on pull requests) |
+|---|---|---|
+| Run Performance Test | read-only production cache | namespace `ci-<sha>`, fallback **on**, writable |
+| Run Legacy Performance Test | read-only production cache | namespace `ci-<sha>`, fallback **on**, writable |
+| Run Connectivity Tests | cache **off** entirely | namespace `ci-<sha>`, fallback **off**, writable |
+
+Push-to-`main` and scheduled runs are untouched: no namespace, so they still write the production
+cache and keep it warm for the deployed service.
+
+The namespace is keyed on `github.sha`, not the branch. Keying on the branch would let an entry
+written by a bad push be served to the run that was supposed to validate the fix — a green tick for
+code that never actually ran. Per-commit keying gives up warmth *between* pushes and keeps it where
+the cost concentrates: the auto-retry, which today re-pays the full cold cost of everything attempt 1
+already computed.
+
+Entries expire after 12 hours (`VFBQUERY_CACHE_TTL_HOURS`), so abandoned commits collect themselves.
+There is no purge step: a namespace whose run is still in flight must not have the ground pulled out
+from under it, and the TTL is shorter than the cases where that would matter.

--- a/docs/ci/performance-test.yml
+++ b/docs/ci/performance-test.yml
@@ -149,10 +149,25 @@ jobs:
           # pushed after a bad run must not be validated against entries the
           # bad code wrote.
           #
+          # Unconditional, unlike the two steps above. Those vary by event
+          # because on push and schedule they deliberately write the production
+          # cache to keep it warm for the deployed service. This step never did
+          # — it ran with the cache off on every event — so there is nothing to
+          # preserve here: namespacing it on every event takes nothing away
+          # from production warming and gives push and scheduled runs the same
+          # warm retry a pull request gets.
+          #
+          # This is NOT a fix for the runs currently timing out. #743 to #748
+          # were all cancelled at 2h05 on the 120-minute ceiling, but this
+          # workflow file is byte-identical to the one that finished in ~7
+          # minutes at 73b919d, so that regression came in with the code merged
+          # in 2c29b33 (PR #82) and has to be found there. A warm retry cannot
+          # rescue a job whose first attempt does not finish.
+          #
           # Net effect: attempt 1 is as slow as today; the auto-retry below,
           # which is where the doubling cost lives, is warm.
-          VFBQUERY_CACHE_ENABLED: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-          VFBQUERY_CACHE_NAMESPACE: ${{ github.event_name == 'pull_request' && format('ci-{0}', github.sha) || '' }}
+          VFBQUERY_CACHE_ENABLED: 'true'
+          VFBQUERY_CACHE_NAMESPACE: ci-${{ github.sha }}
           VFBQUERY_CACHE_NAMESPACE_FALLBACK: 'false'
           VFBQUERY_CACHE_TTL_HOURS: '12'
           VFBQUERY_CACHE_READONLY: 'false'

--- a/docs/ci/performance-test.yml
+++ b/docs/ci/performance-test.yml
@@ -1,0 +1,435 @@
+name: Performance Test
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+  workflow_dispatch:  # Enables manual triggering
+  schedule:
+    - cron: '0 2 * * *'  # Runs daily at 2 AM UTC
+
+jobs:
+  performance:
+    name: "Performance Test"
+    runs-on: ubuntu-latest
+    # Raised from 60: the job runs the performance, legacy-performance and
+    # connectivity suites back-to-back, each hitting live VFB infra (Neo4j /
+    # SOLR / Owlery) with an auto-retry on first failure, so a cold/loaded run
+    # legitimately exceeds an hour. Still bounded to stop a genuinely hung run.
+    timeout-minutes: 120  # Set a timeout to prevent jobs from running indefinitely
+    defaults:
+      run:
+        # pipefail so `python -m unittest ... | tee` propagates unittest's exit
+        # status instead of always returning tee's 0.
+        shell: bash -o pipefail -e {0}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade -r requirements.txt
+          python -m pip install -e .  # Editable install ensures we test the actual source code
+          # pytest-xdist powers the `-n auto` parallel run in the
+          # Connectivity Tests step below. Installed here rather than in
+          # requirements.txt because it's only needed at test time.
+          python -m pip install pytest-xdist
+      
+      - name: Test Owlery Connectivity
+        run: |
+          echo "Testing basic connectivity to Owlery server..."
+          curl -v --max-time 30 "http://owl.virtualflybrain.org/kbs/vfb/subclasses?object=%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FFBbt_00005106%3E&direct=false&includeDeprecated=false&includeEquivalent=true" | head -20 || echo "Simple query failed or timed out"
+          echo ""
+          echo "Testing if server responds at all..."
+          curl -v --max-time 10 "http://owl.virtualflybrain.org/kbs/vfb" || echo "Server unreachable"
+          
+      - name: Run Performance Test
+        # Switched from `python -m unittest` (single-threaded) to `pytest -n auto`
+        # so the suite parallelises across the runner's vCPUs. pytest discovers
+        # unittest.TestCase subclasses automatically; no test refactoring needed.
+        # Auto-retry once on failure: cold-start runs hit Neo4j + SOLR with empty
+        # result caches and can breach thresholds on first-call latency. The
+        # retry runs warm. If both fail, surface the failure.
+        # IMPORTANT: the retry OVERWRITES performance_test_output.log so the
+        # downstream "Fail job on test failures" step grades on the second
+        # attempt's output only.
+        env:
+          # On a PR: a private cache namespace, so this branch reads and WRITES
+          # its own entries and cannot address a production document at all.
+          # Fallback is on because these are timing assertions — a production
+          # entry is a fair stand-in on the first run, and it means a new branch
+          # measures warm latency immediately instead of grading a cold path
+          # nobody in production takes.
+          # Keyed on the COMMIT, not the branch: an entry written by an earlier
+          # push must never be served to a later one, or a branch could be
+          # graded on results its current code did not produce. Within a run
+          # that still makes the auto-retry warm, which is where the doubling
+          # cost actually lives.
+          # On push-to-main / schedule: no namespace, so these runs write the
+          # production cache and keep it warm for the deployed service.
+          VFBQUERY_CACHE_NAMESPACE: ${{ github.event_name == 'pull_request' && format('ci-{0}', github.sha) || '' }}
+          VFBQUERY_CACHE_NAMESPACE_FALLBACK: 'true'
+          VFBQUERY_CACHE_TTL_HOURS: '12'
+          # Deliberately writable everywhere now: on PRs the namespace is what
+          # protects production, not read-only mode. See CACHING.md.
+          VFBQUERY_CACHE_READONLY: 'false'
+        run: |
+          set +e
+          echo "=== Performance test attempt 1/2 (parallel) ==="
+          pytest -v -s -n auto src/test/test_query_performance.py 2>&1 | tee performance_test_output.log
+          FIRST_EXIT=${PIPESTATUS[0]}
+          if [[ $FIRST_EXIT -eq 0 ]]; then
+              exit 0
+          fi
+          echo ""
+          echo "=== Attempt 1 failed (exit $FIRST_EXIT). Retrying once with warm cache. ==="
+          echo "=== RETRY ATTEMPT (auto-retry on first failure) ===" > performance_test_output.log
+          pytest -v -s -n auto src/test/test_query_performance.py 2>&1 | tee -a performance_test_output.log
+          exit ${PIPESTATUS[0]}
+
+      - name: Run Legacy Performance Test
+        # Always run, even if the previous test step failed, so we still get
+        # the report data and don't mask additional regressions.
+        if: always()
+        env:
+          VFBQUERY_CACHE_ENABLED: 'true'
+          # Same arrangement as the step above: namespaced + fallback on PRs,
+          # production on push-to-main and scheduled runs.
+          VFBQUERY_CACHE_NAMESPACE: ${{ github.event_name == 'pull_request' && format('ci-{0}', github.sha) || '' }}
+          VFBQUERY_CACHE_NAMESPACE_FALLBACK: 'true'
+          VFBQUERY_CACHE_TTL_HOURS: '12'
+          VFBQUERY_CACHE_READONLY: 'false'
+          MPLBACKEND: 'Agg'
+          VISPY_GL_LIB: 'osmesa'
+          VISPY_USE_EGL: '0'
+        run: |
+          set +e
+          # Each test step uses a per-step log so the canonical
+          # performance_test_output.log only contains the LAST run's output
+          # (after any retry). Step-local logs are concatenated at the end
+          # for human inspection.
+          echo "=== Legacy performance test attempt 1/2 ==="
+          python -m unittest -v src.test.term_info_queries_test.TermInfoQueriesTest.test_term_info_performance 2>&1 | tee legacy_attempt.log
+          FIRST_EXIT=${PIPESTATUS[0]}
+          if [[ $FIRST_EXIT -eq 0 ]]; then
+              cat legacy_attempt.log >> performance_test_output.log
+              exit 0
+          fi
+          echo ""
+          echo "=== Legacy attempt 1 failed (exit $FIRST_EXIT). Retrying once with warm cache. ==="
+          python -m unittest -v src.test.term_info_queries_test.TermInfoQueriesTest.test_term_info_performance 2>&1 | tee legacy_attempt.log
+          RETRY_EXIT=${PIPESTATUS[0]}
+          echo "=== LEGACY RETRY ATTEMPT ===" >> performance_test_output.log
+          cat legacy_attempt.log >> performance_test_output.log
+          exit $RETRY_EXIT
+
+      - name: Run Connectivity Tests
+        if: always()
+        env:
+          # These assert on result CONTENT, so they must never be served an
+          # entry written by different code. Previously that meant switching the
+          # cache off entirely (VFBQUERY_CACHE_ENABLED=false) and paying full
+          # cold Neo4j cost on every single run, including re-runs of an
+          # unchanged branch.
+          #
+          # A namespace gives the same guarantee more cheaply: the only entries
+          # readable here are ones THIS BRANCH wrote, on an earlier attempt or an
+          # earlier push. Fallback is OFF — falling back to production would
+          # reintroduce exactly the stale-result problem, since a production
+          # entry was computed by main's code, not this branch's.
+          #
+          # Keyed on the COMMIT for the same reason as the step above: a fix
+          # pushed after a bad run must not be validated against entries the
+          # bad code wrote.
+          #
+          # Net effect: attempt 1 is as slow as today; the auto-retry below,
+          # which is where the doubling cost lives, is warm.
+          VFBQUERY_CACHE_ENABLED: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          VFBQUERY_CACHE_NAMESPACE: ${{ github.event_name == 'pull_request' && format('ci-{0}', github.sha) || '' }}
+          VFBQUERY_CACHE_NAMESPACE_FALLBACK: 'false'
+          VFBQUERY_CACHE_TTL_HOURS: '12'
+          VFBQUERY_CACHE_READONLY: 'false'
+          MPLBACKEND: 'Agg'
+          VISPY_GL_LIB: 'osmesa'
+          VISPY_USE_EGL: '0'
+        run: |
+          # These files are pytest-style (plain classes + @pytest.mark.integration).
+          # Run with pytest so the markers are honoured and collection works.
+          # `-n auto` parallelises across all available CPU cores via
+          # pytest-xdist (typically 2-4 on GitHub-hosted ubuntu runners). The
+          # connectivity tests hit the live upstream and don't share fixtures
+          # or in-process state, so they parallelise cleanly. SOLR cache writes
+          # are idempotent so a race between two cold workers on the same
+          # term_id just produces two identical writes.
+          # Auto-retry once on failure — same rationale as Run Performance Test.
+          # Per-step log is concatenated into the canonical
+          # performance_test_output.log only after the final (possibly retried)
+          # attempt, so the failure-detection step at the end of the workflow
+          # grades on the last attempt only.
+          set +e
+          echo "=== Connectivity test attempt 1/2 (parallel) ==="
+          pytest -v -s -n 8 \
+            src/test/test_neuron_neuron_connectivity.py \
+            src/test/test_neuron_region_connectivity.py \
+            src/test/test_upstream_class_connectivity.py \
+            src/test/test_downstream_class_connectivity.py \
+            src/test/test_vfb_connectivity.py \
+            2>&1 | tee connectivity_attempt.log
+          FIRST_EXIT=${PIPESTATUS[0]}
+          if [[ $FIRST_EXIT -eq 0 ]]; then
+              cat connectivity_attempt.log >> performance_test_output.log
+              exit 0
+          fi
+          echo ""
+          echo "=== Connectivity attempt 1 failed (exit $FIRST_EXIT). Retrying once with warm cache. ==="
+          pytest -v -s -n 8 \
+            src/test/test_neuron_neuron_connectivity.py \
+            src/test/test_neuron_region_connectivity.py \
+            src/test/test_upstream_class_connectivity.py \
+            src/test/test_downstream_class_connectivity.py \
+            src/test/test_vfb_connectivity.py \
+            2>&1 | tee connectivity_attempt.log
+          RETRY_EXIT=${PIPESTATUS[0]}
+          echo "=== CONNECTIVITY RETRY ATTEMPT ===" >> performance_test_output.log
+          cat connectivity_attempt.log >> performance_test_output.log
+          exit $RETRY_EXIT
+
+      - name: Create Performance Report
+        if: always()  # Always run this step, even if the test fails
+        run: |
+          # Create performance.md file
+          cat > performance.md << EOF
+          # VFBquery Performance Test Results
+          
+          **Test Date:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          **Git Commit:** ${{ github.sha }}
+          **Branch:** ${{ github.ref_name }}
+          **Workflow Run:** [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          
+          ## Test Overview
+          
+          This performance test measures the execution time of all implemented VFB queries organized by functionality:
+          
+          ### 1. Term Information Queries
+          
+          - **Term Info**: Comprehensive term information retrieval with preview data
+          
+          ### 2. Neuron Part & Synaptic Queries
+          
+          - **NeuronsPartHere**: Neurons with parts overlapping anatomical regions
+          - **NeuronsSynaptic**: Neurons with synapses in a region
+          - **NeuronsPresynapticHere**: Neurons with presynaptic terminals in a region
+          - **NeuronsPostsynapticHere**: Neurons with postsynaptic terminals in a region
+          
+          ### 3. Anatomical Hierarchy Queries
+          
+          - **ComponentsOf**: Anatomical components of a structure
+          - **PartsOf**: Parts of an anatomical structure
+          - **SubclassesOf**: Subclasses of anatomical terms (can be very slow for complex terms)
+          
+          ### 4. Tract/Nerve & Lineage Queries
+          
+          - **NeuronClassesFasciculatingHere**: Neurons fasciculating with tracts
+          - **TractsNervesInnervatingHere**: Tracts/nerves innervating neuropils
+          - **LineageClonesIn**: Lineage clones in neuropils (complex OWL reasoning)
+          
+          ### 5. Image & Developmental Queries
+          
+          - **ImagesNeurons**: Neuron images in anatomical regions
+          - **ImagesThatDevelopFrom**: Developmental lineage images
+          - **epFrag**: Expression pattern fragments
+          - **ListAllAvailableImages**: All available images for a term
+          
+          ### 6. Connectivity Queries
+          
+          - **NeuronNeuronConnectivity**: Neuron-to-neuron connectivity
+          - **NeuronRegionConnectivity**: Neuron-to-region connectivity
+          - **NeuronInputsTo**: Individual neuron inputs
+          
+          ### 7. Similarity Queries (NBLAST & NeuronBridge)
+          
+          - **SimilarMorphologyTo**: NBLAST morphological similarity
+          - **SimilarMorphologyToPartOf**: NBLAST to expression patterns (NBLASTexp)
+          - **SimilarMorphologyToPartOfexp**: Reverse NBLASTexp
+          - **SimilarMorphologyToNB**: NeuronBridge matches
+          - **SimilarMorphologyToNBexp**: NeuronBridge for expression patterns
+          
+          ### 8. Expression & Transcriptomics Queries
+          
+          - **ExpressionOverlapsHere**: Expression patterns overlapping regions
+          - **anatScRNAseqQuery**: scRNAseq clusters in anatomy
+          - **clusterExpression**: Genes expressed in clusters
+          - **expressionCluster**: Clusters expressing genes
+          - **scRNAdatasetData**: Cluster data from scRNAseq datasets
+          
+          ### 9. Dataset & Template Queries
+          
+          - **PaintedDomains**: Template painted anatomy domains
+          - **DatasetImages**: Images in datasets
+          - **AllAlignedImages**: Images aligned to templates
+          - **AlignedDatasets**: Datasets aligned to templates
+          - **AllDatasets**: All available datasets
+          
+          ### 10. Publication & Transgene Queries
+          
+          - **TermsForPub**: Terms referencing publications
+          - **TransgeneExpressionHere**: Transgene expression patterns in regions
+          
+          ## Performance Thresholds
+          
+          - **Fast queries**: < 1 second (SOLR lookups)
+          - **Medium queries**: < 3 seconds (Owlery + SOLR)
+          - **Slow queries**: < 10 seconds (Neo4j + complex processing)
+          - **Very Slow queries**: < 31 seconds (Complex OWL reasoning - over 30 seconds)
+          
+          ## Test Results
+          
+          \`\`\`
+          $(cat performance_test_output.log)
+          \`\`\`
+          
+          ## Summary
+          
+          EOF
+          
+          # Check overall test status. Note: matching "OK" or "ok" would
+          # false-positive on per-test "test_foo ... ok" lines emitted by
+          # unittest -v even when other tests failed. Use the absence of
+          # FAIL:/ERROR: lines as the truth source (mirrors the final
+          # "Fail job on test failures" step).
+          # unittest summary: "Ran N tests in Xs".
+          # pytest summary line ends with " in X.XXs" prefixed by " passed", " failed",
+          # " error", or "no tests ran". Match either runner's summary markers.
+          if grep -q "Ran .* test\| passed in \| failed in \| error in \|no tests ran" performance_test_output.log; then
+            # unittest emits "FAIL:" / "ERROR:"; pytest emits "FAILED " / "ERROR " (no colon).
+            if grep -q "FAIL:\|ERROR:\|FAILED\b\|^ERROR\b" performance_test_output.log; then
+              echo "❌ **Test Status**: Performance tests ran but reported failures" >> performance.md
+            else
+              echo "✅ **Test Status**: Performance tests completed" >> performance.md
+            fi
+            echo "" >> performance.md
+            
+            # Count successes and failures. The log mixes both unittest
+            # (`test_xxx ... ok`/`FAIL:`/`ERROR:`) and pytest
+            # (`... PASSED`/`FAILED`/`ERROR` lines) outputs depending on
+            # which step wrote it. Sum both formats so the report shows a
+            # meaningful total instead of "Total: 1" (which is what we got
+            # when only the unittest-format legacy step matched).
+            #
+            # `grep -c` already prints `0` and exits 1 on no-match, so
+            # `|| true` is needed to swallow the exit code (otherwise
+            # set -e aborts the step). Default empty captures to 0.
+            UNITTEST_TESTS=$(grep -cE "^test_" performance_test_output.log 2>/dev/null || true)
+            PYTEST_TESTS=$(grep -cE " (PASSED|FAILED|ERROR)( |$)" performance_test_output.log 2>/dev/null || true)
+            UNITTEST_FAIL=$(grep -cE "^(FAIL|ERROR):" performance_test_output.log 2>/dev/null || true)
+            PYTEST_FAIL=$(grep -cE " (FAILED|ERROR)( |$)" performance_test_output.log 2>/dev/null || true)
+            UNITTEST_TESTS=${UNITTEST_TESTS:-0}
+            PYTEST_TESTS=${PYTEST_TESTS:-0}
+            UNITTEST_FAIL=${UNITTEST_FAIL:-0}
+            PYTEST_FAIL=${PYTEST_FAIL:-0}
+            TOTAL_TESTS=$((UNITTEST_TESTS + PYTEST_TESTS))
+            FAILED_TESTS=$((UNITTEST_FAIL + PYTEST_FAIL))
+            ERROR_TESTS=0  # ERROR counts already folded into FAILED above
+            PASSED_TESTS=$((TOTAL_TESTS - FAILED_TESTS))
+            
+            echo "### Test Statistics" >> performance.md
+            echo "" >> performance.md
+            echo "- **Total Tests**: ${TOTAL_TESTS}" >> performance.md
+            echo "- **Passed**: ${PASSED_TESTS} ✅" >> performance.md
+            echo "- **Failed**: ${FAILED_TESTS} ❌" >> performance.md
+            echo "- **Errors**: ${ERROR_TESTS} ⚠️" >> performance.md
+            echo "" >> performance.md
+            
+            # Extract timing information for key queries
+            echo "### Query Performance Details" >> performance.md
+            echo "" >> performance.md
+            
+            # Extract all timing lines
+            if grep -q "seconds" performance_test_output.log; then
+              echo "| Query | Duration | Status |" >> performance.md
+              echo "|-------|----------|--------|" >> performance.md
+              
+              # Parse timing information. The `|| true` guards against pipefail
+              # propagating grep's exit-1 (no matches) into the step — which
+              # was happening when pytest captured stdout and the per-query
+              # timing lines never landed in the log.
+              { grep -E "^(get_term_info|NeuronsPartHere|NeuronsSynaptic|NeuronsPresynapticHere|NeuronsPostsynapticHere|ComponentsOf|PartsOf|SubclassesOf|NeuronClassesFasciculatingHere|TractsNervesInnervatingHere|LineageClonesIn|ListAllAvailableImages|NeuronNeuronConnectivityQuery|NeuronRegionConnectivityQuery|NeuronInputsTo|DownstreamClassConnectivity|UpstreamClassConnectivity|QueryConnectivity):" performance_test_output.log || true; } | while read line; do
+                QUERY=$(echo "$line" | sed 's/:.*//')
+                DURATION=$(echo "$line" | sed 's/.*: \([0-9.]*\)s.*/\1/')
+                if echo "$line" | grep -q "✅"; then
+                  STATUS="✅ Pass"
+                else
+                  STATUS="❌ Fail"
+                fi
+                echo "| $QUERY | ${DURATION}s | $STATUS |" >> performance.md
+              done
+            fi
+            
+            echo "" >> performance.md
+            
+            # Overall result
+            if [ "$FAILED_TESTS" -eq "0" ] && [ "$ERROR_TESTS" -eq "0" ]; then
+              echo "🎉 **Result**: All performance thresholds met!" >> performance.md
+            else
+              echo "⚠️ **Result**: Some performance thresholds exceeded or tests failed" >> performance.md
+              echo "" >> performance.md
+              echo "Please review the failed tests above. Common causes:" >> performance.md
+              echo "- Network latency to VFB services" >> performance.md
+              echo "- SOLR/Neo4j/Owlery server load" >> performance.md
+              echo "- First-time cache population (expected to be slower)" >> performance.md
+            fi
+          else
+            echo "❌ **Test Status**: Performance tests failed to run properly" >> performance.md
+            echo "" >> performance.md
+            echo "Please check the test output above for errors." >> performance.md
+          fi
+          
+          echo "" >> performance.md
+          echo "---" >> performance.md
+          echo "" >> performance.md
+          echo "## Historical Performance" >> performance.md
+          echo "" >> performance.md
+          echo "Track performance trends across commits:" >> performance.md
+          echo "- [GitHub Actions History](https://github.com/${{ github.repository }}/actions/workflows/performance-test.yml)" >> performance.md
+          echo "" >> performance.md
+          echo "---" >> performance.md
+          echo "*Last updated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')*" >> performance.md
+          
+          # Also add to GitHub step summary
+          echo "## Performance Test Report" >> $GITHUB_STEP_SUMMARY
+          echo "Performance results have been saved to performance.md" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          cat performance.md >> $GITHUB_STEP_SUMMARY
+          
+      - name: Commit and Push Performance Report
+        if: always() && github.ref == 'refs/heads/main'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add performance.md
+          git diff --staged --quiet || git commit -m "Update performance test results [skip ci]"
+          git push origin HEAD:main
+
+      - name: Fail job on test failures
+        # Belt-and-braces: pipefail on the test steps should already make the
+        # job red on any unittest failure. This grep is a safety net in case a
+        # future test runner emits FAIL/ERROR lines without a non-zero exit
+        # (e.g. partial runs, swallowed pipelines). Runs after the report and
+        # commit so those still happen.
+        if: always()
+        run: |
+          # Match both unittest format ("FAIL:" / "ERROR:") and pytest format
+          # ("FAILED " / "ERROR " — no colon) so this catches either runner.
+          if grep -q "FAIL:\|ERROR:\|FAILED\b\|^ERROR\b" performance_test_output.log; then
+            echo "::error::Test run reported FAIL or ERROR lines in performance_test_output.log"
+            grep "FAIL:\|ERROR:\|FAILED\b\|^ERROR\b" performance_test_output.log
+            exit 1
+          fi
+          echo "No FAIL/ERROR lines detected."

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -6,9 +6,11 @@ are plain `GET` requests returning JSON and there is nothing wrong with calling 
 website and the MCP server do.
 
 ```{note}
-`/search`, `/xref` and `/combine` are new in this branch and are **not yet on the public deploy**.
-Until they are, run the service locally to use them:
-`python -m vfbquery.ha_api --port 8080` and point at `http://localhost:8080`.
+`/search`, `/xref`, `/facets` and `/combine` went live with 1.22.35 and are on the public deploy.
+`https://vfbquery.virtualflybrain.org` is the service itself; `https://v3-cached.virtualflybrain.org`
+is an nginx cache in front of it. The cache is the right default — it is what the website and the MCP
+use — but it does not honour `Cache-Control: no-cache`, so a body it is holding expires on its own TTL.
+Call the service host directly when you need to see the current answer rather than the cached one.
 ```
 
 ## Endpoints
@@ -37,9 +39,17 @@ called". Use `/search`.
 ```
 
 There is a second hierarchy route, `/get_hierarchy_html`, which returns the same tree as a rendered
-HTML page. It stays inside the cluster network (it is not in `ALLOWED_PATHS`, so it 404s from
-outside) because it exists to serve one consumer — the ROI browser on the geppetto site — and its
-markup is that consumer's presentation, not an API contract. The JSON carries the same tree.
+HTML page. It exists to serve one consumer — the ROI browser on the geppetto site — and its markup is
+that consumer's presentation, not an API contract, so treat it as internal and use `/get_hierarchy`
+for the same tree as JSON.
+
+```{warning}
+Internal by convention, not by enforcement. `ALLOWED_PATHS` is checked against `request.remote`, and
+behind the Kubernetes ingress `request.remote` is the ingress — an address inside `TRUSTED_NETWORKS`
+— so on the public deploy the allowlist matches nothing and every routed path answers. Making it
+effective means trusting `X-Forwarded-For`, which changes who can reach what; it is deliberately not
+being done as part of a patch release. Do not rely on the allowlist as an access control.
+```
 
 ## `/get_term_info`
 
@@ -81,7 +91,7 @@ GET /query_connectivity?upstream_type=DA1 lPN&downstream_type=Kenyon cell
 | `upstream_type`, `downstream_type` | Neuron type labels, synonyms or FBbt ids. **At least one is required**; giving one asks "everything downstream of / upstream of this". |
 | `weight` | Minimum synapse count for a connection to be reported. Default 5. |
 | `group_by_class` | `true` aggregates to one row per class pair, with `pairwise_connections`, `average_weight` and `percent_connected`. Default is one row per neuron pair. |
-| `exclude_dbs` | Comma-separated dataset symbols to leave out. Defaults to `hb,fafb` — see below. Pass `exclude_dbs=` (empty) for every dataset. |
+| `exclude_dbs` | Comma-separated datasets to leave out. Defaults to `hb,fafb` — see below. Pass `exclude_dbs=` (empty) for every dataset. A symbol (`mc`), a short_form (`male_cns_v0_9`), a label (`male-cns`) or the whole label all name the same dataset; an unrecognised one is a **400** with suggestions. |
 | `include_graph` | Attach a graph structure alongside the table. |
 | `force_refresh` | Bypass the cache. |
 
@@ -107,6 +117,16 @@ a count surprises you.
 }
 ```
 
+The response also echoes **`excluded_dbs`**: the datasets the answer actually leaves out, canonicalised
+to symbols. Reading it beats re-deriving it from the query string, and it is the only way to see what a
+request that sent no `exclude_dbs` at all was filtered to.
+
+Until 1.22.36 an `exclude_dbs` value that was not letter-for-letter a symbol or a short_form excluded
+**nothing** and said nothing about it — `exclude_dbs=hemibrain` returned the same double-counted answer
+as sending no filter, wearing a 200. Values are now resolved against the live dataset list first, an
+unrecognised one is a 400, and a spelling that had to be rewritten is reported in `warnings`. The
+canonical form is the symbol, which is what the default already was, so cached answers are unaffected.
+
 Labels resolve through exact match, then case-insensitive, then exact synonym, then — as a last
 resort — the only term containing the string. That last tier is what makes `DA1 lPN` find *adult
 antennal lobe projection neuron DA1 lPN*, and when it fires it says so in `warnings`. Two or more
@@ -114,14 +134,25 @@ candidates are never guessed between: the error lists them.
 
 ### How long a broad type takes
 
-Expansion makes some questions large. `DA1 lPN → Kenyon cell` is 68 individuals against 15,994 and
-answers in about 5s; `Tm1 → T3` is 4,915 against 5,430 and has been measured between 30 and 60s on a
-cold cache. The query is driven from whichever side has fewer individuals, which is worth several
-times the difference on an asymmetric pair, but a genuinely big walk is a genuinely big walk.
+Expansion makes some questions large, and how large depends on the *shape* of the pair rather than its
+size. `DA1 lPN → Kenyon cell` is 68 individuals against 15,994 and answers in about 5s: the query is
+driven from whichever side has fewer individuals, and 68 against a filtered id list is a small walk.
 
-The result is cached, so only the first caller waits — which is why the client's read timeout
-defaults to 180s rather than 60s. A workshop room asking the same broad question at the same second
-coalesces onto one query rather than 80.
+An optic-lobe pair is the opposite case. `Tm1 → T3` is 4,915 individuals against 5,430 — no small
+side to drive from — and a cold-cache run of it was measured at **over 40 minutes without returning**.
+Treat a large-against-large type pair as a background job, not a request.
+
+What changed in 1.22.36 is what happens while you wait. The computation now runs detached from the
+request that started it, under `VFBQUERY_COMPUTE_BUDGET` seconds of patience (default 180); when the
+budget runs out you get a **503 `status: "computing"`** with `Retry-After: 30` instead of a connection
+that eventually dies. The work carries on and lands in the cache, so the retry the header asks for is
+the cheap one. Before this, a client giving up cancelled the query it was waiting on, every request
+coalesced behind it was woken with "Request aborted, please retry", and the next caller started the
+same forty minutes from scratch.
+
+The result is cached either way, so only the first caller waits — which is why the client's read
+timeout defaults to 180s rather than 60s. A workshop room asking the same broad question at the same
+second coalesces onto one query rather than 80.
 
 ### Why `hb` and `fafb` are excluded by default
 
@@ -169,8 +200,8 @@ GET /search?query=mushroom body output neuron&limit=25
 | Parameter | |
 |---|---|
 | `query` (or `q`) | **Required.** Free text: a name, a synonym, a symbol, an ID, a bare connectome bodyId. |
-| `rows` | How deep to fetch candidates before ranking. Default 500. Raise it if a known-good hit is missing. |
-| `limit` | Page size of the returned, ranked list. |
+| `rows` | How deep to fetch candidates before ranking. Default 500, capped at `MAX_ROWS`. A value outside the range is clamped **and reported in `warnings`**, because `rows` sizes the pool the comparator ranks — silently shrinking it changes the *order* of the top of your list, not just its length. |
+| `limit` | Page size of the returned, ranked list. Must be at least 1; omit it for no limit. `limit=0` used to return `rows: []` beside a `count` of 1537, which is a result set that reports matches and shows none — it is now a 400. |
 | `filter_types`, `exclude_types` | Hard filters (Solr `fq`) — a term either passes or is not returned. |
 | `boost_types`, `demote_types` | Soft preferences — reorder the ranked list without dropping anything. |
 | `unique` | Collapse the label/synonym rows so each term appears once. Default false. |
@@ -276,6 +307,27 @@ carrying `warnings` should not be treated as an answer without reading them.
 `/combine` goes further, because set algebra over a truncated input is not partially right but wrong:
 `require_complete=true` turns truncation into a 409 refusal.
 
+### Parameters that did nothing now say so
+
+The same convention was extended in 1.22.36 to cover the request rather than only the answer, because
+a parameter that is read and discarded produces a **correct response to a different question**, and
+nothing in the body distinguishes it from the one you asked. Each of these now attaches a `warnings`
+entry:
+
+An **unrecognised parameter** is named back, with the closest real one — `filter_type` gets told about
+`filter_types`, `min_weight` about `weight`, `short_form` about `id`. A **flag with an unusable value**
+is reported rather than read as false: `include_graph=y` and `unique=Y` are not among the accepted
+spellings (`true/1/yes/on` and `false/0/no/off`), and used to be indistinguishable from not passing the
+flag. **`include_graph` on a query type that cannot draw one** now lists the four that can, instead of
+returning a graphless result that reads as "this query has no graph". **`offset`/`limit` on a query
+type that does not page**, a non-integer or negative page parameter, and **an `id` sent to
+`query_type=AllDatasets`** (which takes none, and looked filtered) are all called out. `/combine`'s
+`offset`, `order_by` and `force_refresh` are reserved names that are not implemented; passing one is
+now reported rather than silently skipped.
+
+None of this changes a status code. They are 200s that were already 200s — the only thing that changed
+is that the response no longer looks identical to the one you meant to send.
+
 ## Errors and backpressure
 
 | Status | Means |
@@ -284,10 +336,13 @@ carrying `warnings` should not be treated as an answer without reading them.
 | 404 | Unknown path, or a path not in `ALLOWED_PATHS` for your network. |
 | 409 | `/combine` with `require_complete=true`, where an operand was truncated. |
 | 500 | A genuine fault. `detail` carries `"ExcType: message"`. |
-| 503 | Overloaded — the queue is full. Honour `Retry-After`. |
+| 503 | Two cases, distinguished by the body's `status`. `"computing"` means your query is still running and will be cached — retry per `Retry-After`, and the retry gets the finished answer. Otherwise the queue is full and the request was shed. Honour `Retry-After` in both. |
 
-The 503 is a real design feature rather than a failure: the service holds a bounded queue in front of
-a process pool, and shedding early is what keeps the pool answering the requests it accepted. In a
+Both 503s are design features rather than failures. The shedding one exists because the service holds a
+bounded queue in front of a process pool, and shedding early is what keeps the pool answering the
+requests it accepted. The `status: "computing"` one exists because the alternative to admitting that a
+query is slow is a socket held open until something in the path gives up — and what gave up first used
+to take the computation down with it. In a
 workshop room this matters less than it sounds, because the second half of the design is that
 identical in-flight queries are **coalesced** onto one worker and results are cached for five
 minutes. Eighty people running the same cell is one backend query, not eighty.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,16 @@ markers = [
     "integration: integration tests that exercise the live VFB upstream (Neo4j, SOLR, owlery). Skip via -m 'not integration'.",
 ]
 
+# Ceiling on any single test. The upstream Neo4j intermittently stops answering
+# for minutes at a time; with no per-test bound one test caught in that absorbs
+# the whole job, and the run is killed by the runner's own limit with nothing to
+# say which test was stuck. This turns that into one named failure. It is a
+# backstop, not a performance target — a healthy connectivity query returns in a
+# couple of seconds, so anything near this is already a fault. Needs
+# pytest-timeout; without it pytest warns about the unknown option and carries
+# on, so it degrades to the old behaviour rather than breaking the run.
+timeout = 300
+
 # Silence the marshmallow deprecation warnings that bubble up from inside
 # the library itself (marshmallow/fields.py:582,776,986,1218). Our own
 # code calls to `missing=`/`fields.Field()` have been migrated to

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ get_version
 aiohttp
 psycopg[binary]>=3.0
 pytest
+pytest-timeout

--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -16,17 +16,31 @@ before the client's module-level constants are evaluated.
 """
 import os
 
-#: Fail-fast Neo4j settings for tests. Deliberately much tighter than the
-#: library defaults (120s read, 3 retries): a healthy query against production
-#: returns in a couple of seconds, so 45s is already far beyond normal, and one
-#: retry is enough to ride out a dropped connection without turning a dead
-#: upstream into minutes of waiting per statement.
+#: Fail-fast Neo4j settings for tests. Tighter than the library defaults
+#: (120s read, 3 retries), because one retry is enough to ride out a dropped
+#: connection without turning a dead upstream into minutes of waiting per
+#: statement.
+#:
+#: The read timeout is 180s rather than the 45s first used here. 45s was
+#: chosen on the assumption that a healthy query returns in a couple of
+#: seconds, which is true of most of them and not true of the class-level
+#: connectivity queries: ``get_downstream_class_connectivity('FBbt_00001482')``
+#: is measured at 106s against a healthy production server, returning 9,095
+#: rows. Those tests pass ``force_refresh=True`` and run with the cache
+#: disabled, so every one of them pays that in full — under 45s they did not
+#: time out so much as report an empty table, and nine of them failed on
+#: assertions about rows that had simply never arrived. The tight value was
+#: also invisible until recently: the client used to freeze its constants at
+#: import, so this file's settings never reached the queries at all.
+#:
+#: A stalled server is still bounded — 180s x 2 attempts, and the client now
+#: sends ``max-execution-time`` so the server abandons the work as well.
 #:
 #: ``setdefault``, not assignment — a workflow or a developer that has set one
 #: of these deliberately keeps it.
 TEST_NEO4J_DEFAULTS = {
     "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
-    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
+    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "180",
     "VFBQUERY_NEO4J_MAX_RETRIES": "1",
     "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
     "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",

--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -1,0 +1,42 @@
+"""Test package for VFBquery.
+
+This file exists to hold one piece of setup: the Neo4j client's fail-fast
+settings for tests. It lives here rather than in ``conftest.py`` because
+``conftest.py`` is a pytest mechanism, and not every job runs pytest — the
+conda workflow runs the suite through ``unittest``, which imports
+``src.test.<module>`` and never looks at a conftest. When these defaults were
+in conftest only, that job kept the library's REPL-tuned patience and a single
+statement against a stalled upstream cost 120s x 4 attempts; one test measured
+582s against its own 120s threshold for that reason alone. Importing the
+package is the one thing both runners are guaranteed to do.
+
+The settings are read at import time by ``vfbquery.neo4j_client``, and this
+module is imported before any test module in the package, so they are in place
+before the client's module-level constants are evaluated.
+"""
+import os
+
+#: Fail-fast Neo4j settings for tests. Deliberately much tighter than the
+#: library defaults (120s read, 3 retries): a healthy query against production
+#: returns in a couple of seconds, so 45s is already far beyond normal, and one
+#: retry is enough to ride out a dropped connection without turning a dead
+#: upstream into minutes of waiting per statement.
+#:
+#: ``setdefault``, not assignment — a workflow or a developer that has set one
+#: of these deliberately keeps it.
+TEST_NEO4J_DEFAULTS = {
+    "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
+    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
+    "VFBQUERY_NEO4J_MAX_RETRIES": "1",
+    "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
+    "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",
+}
+
+
+def apply_test_neo4j_defaults():
+    """Set the fail-fast Neo4j environment defaults, leaving any already set."""
+    for name, value in TEST_NEO4J_DEFAULTS.items():
+        os.environ.setdefault(name, value)
+
+
+apply_test_neo4j_defaults()

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -1,0 +1,32 @@
+"""Shared setup for the integration test suite.
+
+The one job here is to make the Neo4j client fail fast under test. The library's
+defaults are tuned for a person at a REPL, who would rather wait than be told to
+try again; a CI job wants the opposite. The upstream at
+pdb.virtualflybrain.org intermittently stops answering for minutes at a time,
+and with the library defaults a single statement caught in that can spend
+several minutes retrying before it gives up — multiplied across the connectivity
+suite, that is the difference between a job that fails in a readable way and one
+the runner kills at its own ceiling with nothing to show for it.
+
+These are read at import time by ``vfbquery.neo4j_client``, so they are set
+here — conftest is imported before any test module — and only when not already
+set, so a workflow or a developer can still override them from the environment.
+"""
+import os
+
+#: Fail-fast Neo4j settings for tests. Deliberately much tighter than the
+#: library defaults (120s read, 3 retries): a healthy connectivity query against
+#: production returns in a couple of seconds, so 45s is already far beyond
+#: normal, and one retry is enough to ride out a dropped connection without
+#: turning a dead upstream into minutes of waiting per statement.
+_TEST_NEO4J_DEFAULTS = {
+    "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
+    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
+    "VFBQUERY_NEO4J_MAX_RETRIES": "1",
+    "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
+    "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",
+}
+
+for _name, _value in _TEST_NEO4J_DEFAULTS.items():
+    os.environ.setdefault(_name, _value)

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -1,32 +1,28 @@
-"""Shared setup for the integration test suite.
+"""Shared pytest setup for the test suite.
 
-The one job here is to make the Neo4j client fail fast under test. The library's
-defaults are tuned for a person at a REPL, who would rather wait than be told to
-try again; a CI job wants the opposite. The upstream at
-pdb.virtualflybrain.org intermittently stops answering for minutes at a time,
-and with the library defaults a single statement caught in that can spend
-several minutes retrying before it gives up — multiplied across the connectivity
-suite, that is the difference between a job that fails in a readable way and one
-the runner kills at its own ceiling with nothing to show for it.
+The Neo4j fail-fast defaults these tests need live in ``src/test/__init__.py``
+rather than here, because not every job runs pytest — the conda workflow drives
+the suite through ``unittest``, which imports ``src.test.<module>`` and never
+reads a conftest. Importing the package is the one thing both runners do.
 
-These are read at import time by ``vfbquery.neo4j_client``, so they are set
-here — conftest is imported before any test module — and only when not already
-set, so a workflow or a developer can still override them from the environment.
+This file re-applies them anyway, so the settings do not depend on pytest having
+imported the parent package first. It is a no-op when it has, because the
+underlying call uses ``os.environ.setdefault``.
 """
-import os
+try:
+    from . import apply_test_neo4j_defaults
+except ImportError:  # collected without the package, e.g. rootdir-relative
+    import os
 
-#: Fail-fast Neo4j settings for tests. Deliberately much tighter than the
-#: library defaults (120s read, 3 retries): a healthy connectivity query against
-#: production returns in a couple of seconds, so 45s is already far beyond
-#: normal, and one retry is enough to ride out a dropped connection without
-#: turning a dead upstream into minutes of waiting per statement.
-_TEST_NEO4J_DEFAULTS = {
-    "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
-    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
-    "VFBQUERY_NEO4J_MAX_RETRIES": "1",
-    "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
-    "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",
-}
+    def apply_test_neo4j_defaults():
+        for name, value in {
+            "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
+            "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
+            "VFBQUERY_NEO4J_MAX_RETRIES": "1",
+            "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
+            "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",
+        }.items():
+            os.environ.setdefault(name, value)
 
-for _name, _value in _TEST_NEO4J_DEFAULTS.items():
-    os.environ.setdefault(_name, _value)
+
+apply_test_neo4j_defaults()

--- a/src/test/test_cache_namespace.py
+++ b/src/test/test_cache_namespace.py
@@ -1,0 +1,251 @@
+"""Tests for the private cache namespace (VFBQUERY_CACHE_NAMESPACE).
+
+The point of the namespace is a safety property, not a feature: a process that
+has one must be *incapable* of addressing a production cache document for
+writing or deleting. These tests assert that property directly on the generated
+Solr ids and on the request bodies, so a future refactor that reintroduces a
+hand-built ``f"vfb_query_..."`` somewhere fails here rather than in production.
+
+No Solr server is contacted: requests is stubbed.
+"""
+import os
+import importlib
+
+import pytest
+
+from vfbquery import solr_result_cache as src_mod
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """Clean namespace env for each test."""
+    for var in ("VFBQUERY_CACHE_NAMESPACE", "VFBQUERY_CACHE_NAMESPACE_FALLBACK",
+                "VFBQUERY_CACHE_READONLY", "VFBQUERY_CACHE_ENABLED",
+                "VFBQUERY_CACHE_TTL_HOURS"):
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+# ---------------------------------------------------------------------------
+# id construction
+# ---------------------------------------------------------------------------
+
+def test_production_ids_are_unchanged(env):
+    """The whole cache depends on this: no namespace => byte-identical ids."""
+    assert src_mod.cache_doc_id_for("term_info", "FBbt_00003748") == \
+        "vfb_query_term_info_FBbt_00003748"
+    assert src_mod.cache_doc_glob() == "vfb_query_*"
+
+
+def test_namespace_prefixes_the_id(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci-pr83")
+    assert src_mod.cache_doc_id_for("term_info", "FBbt_00003748") == \
+        "ns_ci_pr83__vfb_query_term_info_FBbt_00003748"
+
+
+def test_namespace_glob_excludes_production(env):
+    """The production sweep and the CI sweep must not see each other's docs."""
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    ns_glob = src_mod.cache_doc_glob()
+    assert ns_glob == "ns_ci__vfb_query_*"
+    prod_id = src_mod.cache_doc_id_for("term_info", "X", namespace="")
+    assert not prod_id.startswith("ns_ci__"), "production id caught by CI glob"
+    ns_id = src_mod.cache_doc_id_for("term_info", "X")
+    assert not ns_id.startswith("vfb_query_"), "CI id caught by production glob"
+
+
+def test_branch_names_are_sanitised_into_a_safe_solr_term(env):
+    """A raw branch name would break the unescaped `q=id:` term."""
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "fix/silent-noop AND params")
+    ns = src_mod.cache_namespace()
+    assert ns == "fix_silent_noop_and_params"
+    assert all(c.isalnum() or c == "_" for c in ns)
+
+
+def test_namespace_is_length_capped(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "b" * 200)
+    assert len(src_mod.cache_namespace()) == 48
+
+
+def test_blank_namespace_is_production(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "   ")
+    assert src_mod.cache_namespace() == ""
+    assert src_mod.cache_doc_id_for("t", "x") == "vfb_query_t_x"
+
+
+# ---------------------------------------------------------------------------
+# TTL
+# ---------------------------------------------------------------------------
+
+def test_production_ttl_is_three_months(env):
+    assert src_mod.SolrResultCache().ttl_hours == 2160
+
+
+def test_namespaced_ttl_is_short(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    assert src_mod.SolrResultCache().ttl_hours == 48
+
+
+def test_explicit_ttl_overrides_both(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    env.setenv("VFBQUERY_CACHE_TTL_HOURS", "6")
+    assert src_mod.SolrResultCache().ttl_hours == 6
+
+
+def test_invalid_ttl_falls_back_rather_than_raising(env):
+    env.setenv("VFBQUERY_CACHE_TTL_HOURS", "half a day")
+    assert src_mod.SolrResultCache().ttl_hours == 2160
+
+
+# ---------------------------------------------------------------------------
+# read-through fallback
+# ---------------------------------------------------------------------------
+
+class _Recorder:
+    """Records the ids Solr was asked for, and answers from a dict."""
+
+    def __init__(self, docs):
+        self.docs = docs
+        self.gets = []
+        self.posts = []
+
+    def get(self, url, params=None, timeout=None):
+        q = (params or {}).get("q", "")
+        self.gets.append(q)
+        doc_id = q.split("id:", 1)[1] if "id:" in q else q
+        payload = self.docs.get(doc_id)
+        docs = [{"cache_data": payload}] if payload is not None else []
+        return _Resp(200, {"response": {"docs": docs}})
+
+    def post(self, url, data=None, headers=None, params=None, timeout=None):
+        self.posts.append(data)
+        return _Resp(200, {})
+
+
+class _Resp:
+    def __init__(self, status, payload):
+        self.status_code = status
+        self._payload = payload
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+def _envelope(cache, result):
+    """A cache_data field the reader will accept as fresh and current."""
+    import json
+    meta = cache._create_cache_metadata(result)
+    return src_mod._encode_cache_field(json.dumps(meta))
+
+
+def _wire(monkeypatch, recorder):
+    monkeypatch.setattr(src_mod.requests, "get", recorder.get)
+    monkeypatch.setattr(src_mod.requests, "post", recorder.post)
+
+
+def test_namespace_miss_does_not_read_production_by_default(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    cache = src_mod.SolrResultCache()
+    rec = _Recorder({"vfb_query_term_info_X": _envelope(cache, {"name": "prod"})})
+    _wire(env, rec)
+
+    assert cache.get_cached_result("term_info", "X") is None
+    assert len(rec.gets) == 1, "fell through to production without being asked"
+
+
+def test_fallback_serves_the_production_entry(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    env.setenv("VFBQUERY_CACHE_NAMESPACE_FALLBACK", "true")
+    cache = src_mod.SolrResultCache()
+    rec = _Recorder({"vfb_query_term_info_X": _envelope(cache, {"name": "prod"})})
+    _wire(env, rec)
+
+    assert cache.get_cached_result("term_info", "X") == {"name": "prod"}
+    assert rec.gets == ["id:ns_ci__vfb_query_term_info_X", "id:vfb_query_term_info_X"]
+
+
+def test_namespace_hit_never_consults_production(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    env.setenv("VFBQUERY_CACHE_NAMESPACE_FALLBACK", "true")
+    cache = src_mod.SolrResultCache()
+    rec = _Recorder({
+        "ns_ci__vfb_query_term_info_X": _envelope(cache, {"name": "branch"}),
+        "vfb_query_term_info_X": _envelope(cache, {"name": "prod"}),
+    })
+    _wire(env, rec)
+
+    assert cache.get_cached_result("term_info", "X") == {"name": "branch"}
+    assert len(rec.gets) == 1
+
+
+def test_fallback_read_never_purges_the_production_entry(env):
+    """A corrupt production doc must be skipped, not deleted, by a CI run."""
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    env.setenv("VFBQUERY_CACHE_NAMESPACE_FALLBACK", "true")
+    cache = src_mod.SolrResultCache()
+    rec = _Recorder({"vfb_query_term_info_X": "gz:not-actually-gzip"})
+    _wire(env, rec)
+
+    assert cache.get_cached_result("term_info", "X") is None
+    assert rec.posts == [], "a namespaced run deleted a production document"
+
+
+# ---------------------------------------------------------------------------
+# writes
+# ---------------------------------------------------------------------------
+
+def test_writes_land_in_the_namespace_only(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    cache = src_mod.SolrResultCache()
+    rec = _Recorder({})
+    _wire(env, rec)
+
+    assert cache.cache_result("term_info", "X", {"name": "branch"}) is True
+    body = "".join(str(p) for p in rec.posts)
+    assert "ns_ci__vfb_query_term_info_X" in body
+    assert '"id": "vfb_query_term_info_X"' not in body
+
+
+def test_clear_entry_targets_the_namespace_only(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    cache = src_mod.SolrResultCache()
+    rec = _Recorder({})
+    _wire(env, rec)
+
+    cache.clear_cache_entry("term_info", "X")
+    assert rec.posts == ["<delete><id>ns_ci__vfb_query_term_info_X</id></delete>"]
+
+
+# ---------------------------------------------------------------------------
+# purge_namespace
+# ---------------------------------------------------------------------------
+
+def test_purge_namespace_refuses_to_wipe_production(env):
+    cache = src_mod.SolrResultCache()
+    rec = _Recorder({})
+    _wire(env, rec)
+
+    assert cache.purge_namespace() is False
+    assert rec.posts == [], "purge with no namespace issued a delete"
+
+
+def test_purge_namespace_refuses_an_explicit_empty_namespace(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    cache = src_mod.SolrResultCache()
+    rec = _Recorder({})
+    _wire(env, rec)
+
+    assert cache.purge_namespace("") is False
+    assert rec.posts == []
+
+
+def test_purge_namespace_deletes_only_its_own_prefix(env):
+    env.setenv("VFBQUERY_CACHE_NAMESPACE", "ci")
+    cache = src_mod.SolrResultCache()
+    rec = _Recorder({})
+    _wire(env, rec)
+
+    assert cache.purge_namespace() is True
+    assert rec.posts == [
+        "<delete><query>id:ns_ci__vfb_query_*</query></delete>"]

--- a/src/test/test_ha_api_dispatch.py
+++ b/src/test/test_ha_api_dispatch.py
@@ -1,0 +1,340 @@
+"""Unit tests for the 1.22.36 dispatch, budget and parameter-warning changes.
+
+Deliberately free of Neo4j and Solr: every one of these is about the plumbing
+between an HTTP request and a worker, and that plumbing is exactly what a live
+query hides. The compute-budget behaviour in particular can only be tested with
+a worker whose duration is known in advance.
+"""
+import asyncio
+import functools
+
+import pytest
+
+from vfbquery import ha_api
+
+
+def sync(fn):
+    """Run an async test body on a fresh loop.
+
+    Deliberately not pytest-asyncio: the coroutine tests below are the only
+    async ones in the suite, and they are not worth a new test dependency that
+    CI would have to install on every run.
+    """
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(fn(*args, **kwargs))
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+class _Req:
+    """The two attributes of a request the parameter helpers actually read."""
+
+    def __init__(self, **query):
+        self.query = dict(query)
+
+
+def test_flag_warning_silent_on_recognised_values():
+    for value in ("true", "1", "yes", "on", "false", "0", "no", "off", "", "TRUE"):
+        assert ha_api._flag_warning(_Req(f=value), "f") is None, value
+    assert ha_api._flag_warning(_Req(), "f") is None
+
+
+def test_flag_warning_names_the_typo():
+    warn = ha_api._flag_warning(_Req(include_graph="y"), "include_graph")
+    assert warn is not None
+    assert "include_graph" in warn and "'y'" in warn
+    assert "read as false" in warn
+
+
+def test_unknown_param_warning_suggests_the_near_miss():
+    warns = ha_api._unknown_param_warnings(
+        _Req(filter_type="Neuron"), ha_api._SEARCH_PARAMS)
+    assert len(warns) == 1
+    assert "'filter_type'" in warns[0] and "'filter_types'" in warns[0]
+
+
+def test_unknown_param_warning_without_a_near_miss():
+    warns = ha_api._unknown_param_warnings(
+        _Req(utm_source="twitter"), ha_api._SEARCH_PARAMS)
+    assert warns == ["Ignored unrecognised parameter 'utm_source'"]
+
+
+def test_known_params_produce_no_warnings():
+    assert ha_api._unknown_param_warnings(
+        _Req(query="Tm1", rows="500", unique="true"),
+        ha_api._SEARCH_PARAMS) == []
+
+
+def test_empty_known_set_disables_the_check():
+    """A handler that has not declared its parameters must not accuse callers."""
+    assert ha_api._unknown_param_warnings(_Req(anything="1"), None) == []
+
+
+def test_with_warnings_does_not_mutate_the_cached_result():
+    cached = {"rows": [1, 2]}
+    out = ha_api._with_warnings(cached, ["careful"])
+    assert out["warnings"] == ["careful"]
+    assert "warnings" not in cached, "cached dict was mutated in place"
+
+
+def test_with_warnings_appends_to_existing():
+    out = ha_api._with_warnings({"warnings": ["a"]}, ["b"])
+    assert out["warnings"] == ["a", "b"]
+
+
+def test_with_warnings_is_a_noop_without_warnings():
+    cached = {"rows": []}
+    assert ha_api._with_warnings(cached, []) is cached
+
+
+# ---------------------------------------------------------------------------
+# exclude_dbs resolution
+# ---------------------------------------------------------------------------
+
+SITES = [
+    {"label": "FlyWire", "symbol": "fw", "short_form": "flywire783"},
+    {"label": "male CNS", "symbol": "mc", "short_form": "male_cns_v0_9"},
+    {"label": "hemibrain", "symbol": "hb",
+     "short_form": "neuprint_JRC_Hemibrain_1point2point1"},
+    {"label": "Adult Brain (CATMAID)", "symbol": "fafb",
+     "short_form": "catmaid_fafb"},
+]
+
+
+def test_exclude_dbs_short_form_resolves_to_the_symbol():
+    resolved, rewritten = ha_api._resolve_exclude_dbs(["flywire783"], SITES)
+    assert resolved == ["fw"]
+    assert rewritten == ["flywire783"]
+
+
+def test_exclude_dbs_symbol_is_already_canonical():
+    resolved, rewritten = ha_api._resolve_exclude_dbs(["fw"], SITES)
+    assert resolved == ["fw"]
+    assert rewritten == []
+
+
+def test_exclude_dbs_default_resolves_to_itself():
+    """The cache-key property: shipping this must not orphan cached defaults."""
+    from vfbquery.vfb_connectivity import DEFAULT_EXCLUDE_DBS
+    resolved, rewritten = ha_api._resolve_exclude_dbs(
+        list(DEFAULT_EXCLUDE_DBS), SITES)
+    assert resolved == list(DEFAULT_EXCLUDE_DBS)
+    assert rewritten == []
+
+
+def test_exclude_dbs_preserves_caller_order():
+    resolved, _ = ha_api._resolve_exclude_dbs(["fafb", "hb"], SITES)
+    assert resolved == ["fafb", "hb"], "order must not be normalised"
+
+
+def test_exclude_dbs_accepts_a_nickname():
+    """`flywire` is not a spelling of anything, and is what people type."""
+    resolved, rewritten = ha_api._resolve_exclude_dbs(["flywire"], SITES)
+    assert resolved == ["fw"]
+    assert rewritten == ["flywire"]
+
+
+def test_exclude_dbs_unknown_name_raises_with_a_suggestion():
+    with pytest.raises(ha_api.BadParam) as exc:
+        ha_api._resolve_exclude_dbs(["flywire999"], SITES)
+    message = str(exc.value)
+    assert "flywire999" in message
+    assert "flywire783" in message, "no did-you-mean suggestion"
+    assert "/list_connectome_datasets" in message
+
+
+def test_exclude_dbs_nonsense_raises_without_a_suggestion():
+    with pytest.raises(ha_api.BadParam) as exc:
+        ha_api._resolve_exclude_dbs(["zzzzzz"], SITES)
+    assert "zzzzzz" in str(exc.value)
+
+
+def test_exclude_dbs_fails_open_without_a_vocabulary():
+    """An unavailable dataset list must not turn every request into a 400."""
+    resolved, rewritten = ha_api._resolve_exclude_dbs(["anything"], [])
+    assert resolved == ["anything"]
+    assert rewritten == []
+
+
+# ---------------------------------------------------------------------------
+# _shielded
+# ---------------------------------------------------------------------------
+
+@sync
+async def test_shielded_timeout_does_not_cancel_the_work():
+    done = []
+
+    async def work():
+        await asyncio.sleep(0.2)
+        done.append("finished")
+        return "result"
+
+    task = asyncio.ensure_future(work())
+    with pytest.raises(asyncio.TimeoutError):
+        await ha_api._shielded(task, 0.05)
+    assert not task.cancelled(), "the budget cancelled the computation"
+
+    assert await task == "result"
+    assert done == ["finished"]
+
+
+@sync
+async def test_shielded_returns_within_budget():
+    async def work():
+        return 42
+    assert await ha_api._shielded(asyncio.ensure_future(work()), 5) == 42
+
+
+@sync
+async def test_shielded_zero_budget_waits_indefinitely():
+    async def work():
+        await asyncio.sleep(0.05)
+        return "slow"
+    assert await ha_api._shielded(asyncio.ensure_future(work()), 0) == "slow"
+
+
+# ---------------------------------------------------------------------------
+# _spawn_compute
+# ---------------------------------------------------------------------------
+
+class _Cache:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def put(self, key, value):
+        self.store[key] = value
+
+    def invalidate(self, key):
+        self.store.pop(key, None)
+
+
+class _Coalescer:
+    def __init__(self):
+        self.keys = {}
+
+    async def get_or_create(self, key):
+        if key in self.keys:
+            return self.keys[key], False
+        fut = asyncio.get_event_loop().create_future()
+        self.keys[key] = fut
+        return fut, True
+
+    async def remove(self, key):
+        self.keys.pop(key, None)
+
+
+class _Tracker:
+    def __init__(self):
+        self.events = []
+
+    async def enter_queue(self):
+        self.events.append("queue")
+
+    async def leave_queue_start_work(self):
+        self.events.append("start")
+
+    async def finish_work(self, started=False):
+        self.events.append(("finish", started))
+
+    @property
+    def snapshot(self):
+        return {"active": 0, "waiting": 0, "total_served": 0}
+
+
+class _InlinePool:
+    """Stands in for the thread pool: runs the worker on the loop's executor."""
+
+
+def _make_app():
+    return {
+        "result_cache": _Cache(),
+        "pool": None,          # None => loop default executor
+        "semaphore": asyncio.Semaphore(4),
+    }
+
+
+@sync
+async def test_spawn_compute_caches_and_resolves():
+    app = _make_app()
+    coalescer, tracker = _Coalescer(), _Tracker()
+    fut, _ = await coalescer.get_or_create("k")
+
+    task = ha_api._spawn_compute(app, coalescer, tracker, fut, "k",
+                                 lambda a, b: {"rows": [a, b]}, (1, 2))
+    result = await task
+    assert result == {"rows": [1, 2]}
+    assert app["result_cache"].get("k") == {"rows": [1, 2]}
+    assert fut.done() and fut.result() == {"rows": [1, 2]}
+    assert ("finish", True) in tracker.events
+
+
+@sync
+async def test_spawn_compute_survives_a_handler_that_gives_up():
+    """The regression this whole change exists for.
+
+    The handler stops waiting after its budget; the computation must still land
+    in the cache so the caller's retry is cheap instead of starting over.
+    """
+    app = _make_app()
+    coalescer, tracker = _Coalescer(), _Tracker()
+    fut, _ = await coalescer.get_or_create("slow")
+
+    def slow_worker():
+        import time
+        time.sleep(0.3)
+        return {"rows": ["expensive"]}
+
+    task = ha_api._spawn_compute(app, coalescer, tracker, fut, "slow",
+                                 slow_worker, ())
+    with pytest.raises(asyncio.TimeoutError):
+        await ha_api._shielded(task, 0.05)
+
+    assert app["result_cache"].get("slow") is None, "not finished yet"
+    await asyncio.wait_for(asyncio.shield(task), 5)
+    assert app["result_cache"].get("slow") == {"rows": ["expensive"]}
+
+
+@sync
+async def test_spawn_compute_store_hook_shapes_what_is_cached():
+    app = _make_app()
+    coalescer, tracker = _Coalescer(), _Tracker()
+    fut, _ = await coalescer.get_or_create("k")
+
+    task = ha_api._spawn_compute(app, coalescer, tracker, fut, "k",
+                                 lambda: {"rows": [1, 2, 3]}, (),
+                                 store=lambda r: {"rows": r["rows"][:1]})
+    assert await task == {"rows": [1]}
+    assert app["result_cache"].get("k") == {"rows": [1]}
+
+
+@sync
+async def test_spawn_compute_propagates_failure_to_waiters():
+    app = _make_app()
+    coalescer, tracker = _Coalescer(), _Tracker()
+    fut, _ = await coalescer.get_or_create("boom")
+
+    def failing():
+        raise RuntimeError("neo4j said no")
+
+    task = ha_api._spawn_compute(app, coalescer, tracker, fut, "boom",
+                                 failing, ())
+    with pytest.raises(RuntimeError):
+        await task
+    assert fut.done() and isinstance(fut.exception(), RuntimeError)
+    assert app["result_cache"].get("boom") is None
+    assert "boom" not in coalescer.keys
+
+
+@sync
+async def test_computing_response_is_503_with_retry_after():
+    resp = ha_api._computing_response("key", 180)
+    assert resp.status == 503
+    assert resp.headers["Retry-After"] == "30"
+    assert b"still being computed" in resp.body

--- a/src/test/test_query_performance.py
+++ b/src/test/test_query_performance.py
@@ -397,16 +397,25 @@ class QueryPerformanceTest(unittest.TestCase):
         print("="*80)
 
         # Both-end + group_by_class is the fastest variant per LLM guidance.
-        # giant fiber neuron → peripherally synapsing interneuron is a
-        # known-good pair with non-zero results.
+        #
+        # The downstream side is not ``peripherally synapsing interneuron``,
+        # which was used here until it was measured. All 17 of its connections
+        # to the giant fiber live in ``hb`` or ``fafb``, both of which
+        # ``DEFAULT_EXCLUDE_DBS`` removes, so that pair answered 0 — and since
+        # this test only timed the call, it never noticed it was timing an
+        # empty result. ``giant fiber coupled neuron 2`` gives 42 connections
+        # under the same defaults.
         result, duration, success = self._time_query(
             "QueryConnectivity",
             query_connectivity,
             upstream_type="giant fiber neuron",
-            downstream_type="peripherally synapsing interneuron",
+            downstream_type="giant fiber coupled neuron 2",
             group_by_class=True,
         )
         print(f"QueryConnectivity: {duration:.4f}s {'✅' if success else '❌'}")
+        # A performance test that passes on an empty table measures nothing.
+        self.assertTrue(success and result and result.get("count", 0) > 0,
+                        "QueryConnectivity returned no connections")
         # Live cross-dataset query — allow up to 5 min per the MCP timeout.
         self.assertLess(duration, 300.0, "QueryConnectivity exceeded threshold")
 
@@ -462,10 +471,20 @@ class QueryPerformanceTest(unittest.TestCase):
         # anatomy classes). Use VFBexp_FBtp0001321 (P{GAL4-per.BS}),
         # known to overlap ~50 anatomy classes in pdb.
         EP_EXAMPLE = 'VFBexp_FBtp0001321'
-        try:
-            get_expression_overlaps_here(EP_EXAMPLE, return_dataframe=False, limit=-1)
-        except Exception:
-            pass  # Ignore warm-up failures
+
+        # Warm the cache — but only where a write can actually land. Under
+        # VFBQUERY_CACHE_READONLY (how every PR check runs) this limit=-1 call
+        # cannot be stored, so it is the uncapped AnatomyExpressedIn traversal
+        # run for nothing: minutes of server time per job, and the shape that
+        # took pdb down. The timed call below asks for ten rows and now gets
+        # exactly that.
+        from vfbquery.solr_result_cache import solr_caching_readonly
+
+        if not solr_caching_readonly():
+            try:
+                get_expression_overlaps_here(EP_EXAMPLE, return_dataframe=False, limit=-1)
+            except Exception:
+                pass  # Ignore warm-up failures
 
         result, duration, success = self._time_query(
             "AnatomyExpressedIn (P{GAL4-per.BS} expression pattern)",

--- a/src/test/test_vfb_connectivity.py
+++ b/src/test/test_vfb_connectivity.py
@@ -1,10 +1,52 @@
-"""Tests for vfb_connectivity module — connectome datasets and neuron connectivity."""
+"""Tests for vfb_connectivity module — connectome datasets and neuron connectivity.
+
+Fixture choice matters here. Every test in this file is an integration test that
+runs against the shared production Neo4j, and CI runs them with the SOLR result
+cache disabled, so each call is paid in full. Two rules keep that affordable:
+
+* Prefer small classes. ``giant fiber neuron`` (8 individuals) and
+  ``peripherally synapsing interneuron`` (6) are used wherever the assertion
+  does not depend on the class being large.
+* Where a large class is the point — ``Kenyon cell`` has no individuals of its
+  own and ~16,000 under its subclasses, which is exactly what the subclass
+  expansion tests exist to check — ask for it with ``group_by_class=True``.
+  That bounds the reply at one row per class pair instead of one per individual
+  pair, so the traversal under test is unchanged while the table that comes
+  back over the wire stays in the tens of rows.
+
+The expensive results are also module-scoped fixtures rather than repeated
+calls, so the three tests that need the same query cost one query between them.
+"""
 import pytest
 
 from vfbquery.vfb_connectivity import list_connectome_datasets, query_connectivity
 
+#: A small, stable pair: 8 and 6 connectivity individuals respectively, one
+#: class each, no subclasses. Cheap enough to query several times.
 KNOWN_UPSTREAM = "giant fiber neuron"
 KNOWN_DOWNSTREAM = "peripherally synapsing interneuron"
+
+#: The subclass-expansion pair. DA1 lPN has 68 individuals; Kenyon cell has none
+#: of its own and ~16,000 across 38 subclasses. Only ever queried grouped.
+EXPANSION_UPSTREAM = "DA1 lPN"
+EXPANSION_UPSTREAM_ID = "FBbt_00067363"
+EXPANSION_DOWNSTREAM = "Kenyon cell"
+EXPANSION_DOWNSTREAM_ID = "FBbt_00003686"
+
+
+@pytest.fixture(scope="module")
+def expansion_result():
+    """DA1 lPN -> Kenyon cell, grouped, run once for the whole module."""
+    return query_connectivity(
+        upstream_type=EXPANSION_UPSTREAM,
+        downstream_type=EXPANSION_DOWNSTREAM,
+        group_by_class=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def datasets():
+    return list_connectome_datasets()
 
 
 # ---------------------------------------------------------------------------
@@ -14,26 +56,22 @@ KNOWN_DOWNSTREAM = "peripherally synapsing interneuron"
 
 class TestListConnectomeDatasets:
     @pytest.mark.integration
-    def test_returns_datasets(self):
-        datasets = list_connectome_datasets()
+    def test_returns_datasets(self, datasets):
         assert len(datasets) > 0
 
     @pytest.mark.integration
-    def test_datasets_have_label_and_symbol(self):
-        datasets = list_connectome_datasets()
+    def test_datasets_have_label_and_symbol(self, datasets):
         for d in datasets:
             assert "label" in d
             assert "symbol" in d
 
     @pytest.mark.integration
-    def test_hemibrain_present(self):
-        datasets = list_connectome_datasets()
+    def test_hemibrain_present(self, datasets):
         symbols = [d["symbol"] for d in datasets]
         assert "hb" in symbols
 
     @pytest.mark.integration
-    def test_every_dataset_has_symbol(self):
-        datasets = list_connectome_datasets()
+    def test_every_dataset_has_symbol(self, datasets):
         for d in datasets:
             assert d["symbol"], f"Dataset {d['label']} has empty symbol"
 
@@ -55,16 +93,25 @@ class TestQueryConnectivityKnown:
 
     @pytest.mark.integration
     def test_both_types_subset_of_either_alone(self):
-        result_both = query_connectivity(
+        # Grouped on all three sides: a one-sided query returns every partner of
+        # the named type, which is the one shape in this file that can run to
+        # thousands of rows. Grouping bounds it at class pairs, and the
+        # containment being asserted holds either way.
+        both = query_connectivity(
             upstream_type=KNOWN_UPSTREAM,
             downstream_type=KNOWN_DOWNSTREAM,
+            group_by_class=True,
         )
-        result_up = query_connectivity(upstream_type=KNOWN_UPSTREAM)
-        result_down = query_connectivity(downstream_type=KNOWN_DOWNSTREAM)
+        up_only = query_connectivity(
+            upstream_type=KNOWN_UPSTREAM, group_by_class=True,
+        )
+        down_only = query_connectivity(
+            downstream_type=KNOWN_DOWNSTREAM, group_by_class=True,
+        )
 
-        assert result_both["count"] > 0
-        assert result_both["count"] <= result_up["count"]
-        assert result_both["count"] <= result_down["count"]
+        assert both["count"] > 0
+        assert both["count"] <= up_only["count"]
+        assert both["count"] <= down_only["count"]
 
 
 class TestQueryConnectivityGroupByClass:
@@ -99,8 +146,7 @@ class TestQueryConnectivityWeightFiltering:
 
 class TestQueryConnectivityExcludeDbs:
     @pytest.mark.integration
-    def test_exclude_all_returns_no_results(self):
-        datasets = list_connectome_datasets()
+    def test_exclude_all_returns_no_results(self, datasets):
         all_symbols = [d["symbol"] for d in datasets]
         result = query_connectivity(
             upstream_type=KNOWN_UPSTREAM,
@@ -115,40 +161,38 @@ class TestQueryConnectivitySubclassExpansion:
     with an empty table that reads as 'not connected'."""
 
     @pytest.mark.integration
-    def test_parent_class_with_no_direct_instances_returns_results(self):
+    def test_parent_class_with_no_direct_instances_returns_results(self, expansion_result):
         # Kenyon cell has zero directly-typed individuals; all ~16,000 sit under
         # its subclasses. Matching the named class alone returns nothing.
-        result = query_connectivity(
-            upstream_type="DA1 lPN", downstream_type="Kenyon cell",
-        )
-        assert result["count"] > 0
-        assert result["resolved"]["downstream"]["classes_searched"] > 1
-        assert result["resolved"]["downstream"]["instances"] > 1000
+        assert expansion_result["count"] > 0
+        assert expansion_result["resolved"]["downstream"]["classes_searched"] > 1
+        assert expansion_result["resolved"]["downstream"]["instances"] > 1000
 
     @pytest.mark.integration
-    def test_resolved_reports_how_a_label_was_read(self):
-        result = query_connectivity(
-            upstream_type="DA1 lPN", downstream_type="Kenyon cell",
-        )
-        up = result["resolved"]["upstream"]
-        assert up["query"] == "DA1 lPN"
-        assert up["id"] == "FBbt_00067363"
+    def test_resolved_reports_how_a_label_was_read(self, expansion_result):
+        up = expansion_result["resolved"]["upstream"]
+        assert up["query"] == EXPANSION_UPSTREAM
+        assert up["id"] == EXPANSION_UPSTREAM_ID
         # A non-exact resolution has to be stated, not silently applied.
-        assert any("DA1 lPN" in w for w in result["warnings"])
+        assert any(EXPANSION_UPSTREAM in w for w in expansion_result["warnings"])
 
     @pytest.mark.integration
     def test_anchor_side_does_not_change_the_answer(self):
         # The query is driven from whichever side has fewer individuals; that is
-        # a performance choice and must not be an answer choice.
+        # a performance choice and must not be an answer choice. Run on the
+        # small pair: forcing the anchor onto Kenyon cell's ~16,000 individuals
+        # tested nothing extra and cost the most of anything in this file.
         from vfbquery.vfb_connectivity import (
             _get_nc, _subclass_closure, _build_connectivity_cypher,
-            DEFAULT_EXCLUDE_DBS,
+            _resolve_neuron_type_label, DEFAULT_EXCLUDE_DBS,
         )
         from vfbquery.neo4j_client import dict_cursor
 
         nc = _get_nc()
-        _, up_ids, _ = _subclass_closure(nc, "FBbt_00067363")   # DA1 lPN
-        _, down_ids, _ = _subclass_closure(nc, "FBbt_00003686")  # Kenyon cell
+        up_id = _resolve_neuron_type_label(nc, KNOWN_UPSTREAM)
+        down_id = _resolve_neuron_type_label(nc, KNOWN_DOWNSTREAM)
+        _, up_ids, _ = _subclass_closure(nc, up_id)
+        _, down_ids, _ = _subclass_closure(nc, down_id)
         counts = []
         for anchor in ("upstream", "downstream"):
             cypher = _build_connectivity_cypher(
@@ -159,8 +203,8 @@ class TestQueryConnectivitySubclassExpansion:
 
     @pytest.mark.integration
     def test_ambiguous_label_lists_candidates(self):
-        # "neuron " (with the trailing space) is contained in a great many
-        # labels and matches none exactly, so it must not be guessed at.
+        # Matches several labels by containment and none exactly, so it must not
+        # be guessed at.
         result = query_connectivity(upstream_type="lobe projection neuron D")
         assert result["count"] == 0
         assert any("ambiguous" in w for w in result["warnings"])
@@ -168,18 +212,20 @@ class TestQueryConnectivitySubclassExpansion:
 
 class TestQueryConnectivityExcludeDbsDefault:
     @pytest.mark.integration
-    def test_default_excludes_are_a_strict_subset_of_everything(self):
+    def test_default_excludes_are_a_strict_subset_of_everything(self, expansion_result):
+        # Grouped, and reusing the module fixture for the default half, so this
+        # costs one extra query rather than two full ungrouped ones over every
+        # dataset — which is what made it the most expensive test here.
         from vfbquery.vfb_connectivity import DEFAULT_EXCLUDE_DBS
 
-        default = query_connectivity(
-            upstream_type="DA1 lPN", downstream_type="Kenyon cell",
-        )
         everything = query_connectivity(
-            upstream_type="DA1 lPN", downstream_type="Kenyon cell",
+            upstream_type=EXPANSION_UPSTREAM,
+            downstream_type=EXPANSION_DOWNSTREAM,
             exclude_dbs=[],
+            group_by_class=True,
         )
         assert DEFAULT_EXCLUDE_DBS == ["hb", "fafb"]
-        assert 0 < default["count"] < everything["count"]
+        assert 0 < expansion_result["count"] < everything["count"]
 
     @pytest.mark.integration
     def test_default_matches_passing_it_explicitly(self):

--- a/src/test/test_vfb_connectivity.py
+++ b/src/test/test_vfb_connectivity.py
@@ -5,8 +5,8 @@ runs against the shared production Neo4j, and CI runs them with the SOLR result
 cache disabled, so each call is paid in full. Two rules keep that affordable:
 
 * Prefer small classes. ``giant fiber neuron`` (8 individuals) and
-  ``peripherally synapsing interneuron`` (6) are used wherever the assertion
-  does not depend on the class being large.
+  ``giant fiber coupled neuron 2`` (30) are used wherever the assertion does
+  not depend on the class being large.
 * Where a large class is the point — ``Kenyon cell`` has no individuals of its
   own and ~16,000 under its subclasses, which is exactly what the subclass
   expansion tests exist to check — ask for it with ``group_by_class=True``.
@@ -21,10 +21,20 @@ import pytest
 
 from vfbquery.vfb_connectivity import list_connectome_datasets, query_connectivity
 
-#: A small, stable pair: 8 and 6 connectivity individuals respectively, one
-#: class each, no subclasses. Cheap enough to query several times.
+#: A small, stable pair: 8 and 30 connectivity individuals respectively, one
+#: class each, no subclasses. Cheap enough to query several times — the two
+#: sides give 42 connections under the default excludes in well under two
+#: seconds.
+#:
+#: The downstream side is deliberately not ``peripherally synapsing
+#: interneuron``, which reads like the obvious partner for the giant fiber and
+#: was used here until it was actually measured. Every one of its 17
+#: connections to ``giant fiber neuron`` lives in ``hb`` or ``fafb``, so
+#: ``DEFAULT_EXCLUDE_DBS`` removes all of them and the pair answers 0 —
+#: silently, since an empty table is a valid answer. A fixture for this file
+#: has to be checked against the *default* excludes, not merely shown to exist.
 KNOWN_UPSTREAM = "giant fiber neuron"
-KNOWN_DOWNSTREAM = "peripherally synapsing interneuron"
+KNOWN_DOWNSTREAM = "giant fiber coupled neuron 2"
 
 #: The subclass-expansion pair. DA1 lPN has 68 individuals; Kenyon cell has none
 #: of its own and ~16,000 across 38 subclasses. Only ever queried grouped.

--- a/src/vfbquery/ha_api.py
+++ b/src/vfbquery/ha_api.py
@@ -488,8 +488,12 @@ ALLOWED_PATHS = frozenset({
     "/resolve_entity", "/find_stocks",
     "/resolve_combination", "/find_combo_publications",
     "/list_connectome_datasets", "/query_connectivity",
-    "/search", "/xref", "/combine", "/get_hierarchy",
+    "/search", "/facets", "/xref", "/combine", "/get_hierarchy",
 })
+# /facets belongs here because /search's four type parameters 400 with
+# "did you mean" suggestions on an unrecognised name and point the caller at
+# /facets for the full list — an allowlist that 404s the endpoint the error
+# message names is a dead end by construction.
 # NB /get_hierarchy_html is a registered route and is deliberately absent here,
 # so it 404s for any client outside TRUSTED_NETWORKS. It is not a query — it is
 # the pre-rendered HTML the geppetto site's ROI browser consumes, produced by
@@ -914,19 +918,32 @@ def _rewrite_resolve_combination_query(name_or_id):
 # HTTP handlers
 # ---------------------------------------------------------------------------
 
+#: Query-string keys /get_term_info reads.
+_TERM_INFO_PARAMS = frozenset({"id", "force_refresh"})
+
+
 async def handle_get_term_info(request):
-    """GET /get_term_info?id=<short_form>"""
+    """GET /get_term_info?id=<short_form>&force_refresh=false"""
     short_form = request.query.get("id")
     if not short_form:
         return web.json_response(
             {"error": "Missing required parameter: id"}, status=400
         )
 
-    force_refresh = request.query.get("force_refresh", "false").lower() in ("true", "1", "yes")
+    force_refresh = _query_flag(request, "force_refresh")
+
+    warnings = _unknown_param_warnings(request, _TERM_INFO_PARAMS)
+    warn = _flag_warning(request, "force_refresh")
+    if warn:
+        warnings.append(warn)
+
+    def finish(result):
+        return web.json_response(_with_warnings(result, warnings))
 
     rcache = request.app["result_cache"]
     coalescer = request.app["coalescer"]
     key = f"term_info:{short_form}"
+    budget = request.app.get("compute_budget", COMPUTE_BUDGET)
 
     # ---- L1: in-memory result cache ----
     # force_refresh=true skips the cache read AND drops any stale entry so the
@@ -939,15 +956,16 @@ async def handle_get_term_info(request):
         cached = rcache.get(key)
         if cached is not None:
             log.info("get_term_info id=%s — cache hit", short_form)
-            return web.json_response(cached)
+            return finish(cached)
 
     # ---- Coalescing: piggyback on identical in-flight query ----
     fut, is_owner = await coalescer.get_or_create(key)
     if not is_owner:
         log.info("get_term_info id=%s — coalesced", short_form)
         try:
-            result = await fut
-            return web.json_response(result)
+            return finish(await _shielded(fut, budget))
+        except asyncio.TimeoutError:
+            return _computing_response(key, budget)
         except Overloaded as exc:
             return _overloaded_response(exc)
         except Exception as exc:
@@ -971,40 +989,30 @@ async def handle_get_term_info(request):
                                retry_after="30")
 
     # ---- Enter the bounded worker queue ----
-    pool = request.app["pool"]
-    sem = request.app["semaphore"]
-
-    await tracker.enter_queue()
     snap = tracker.snapshot
     log.info(
         "get_term_info id=%s — queued  (active=%d waiting=%d)",
         short_form, snap["active"], snap["waiting"],
     )
-    started = False
+    task = _spawn_compute(
+        request.app, coalescer, tracker, fut, key,
+        _run_term_info, (short_form, force_refresh),
+        # Stored uncapped, as it always was: a term info blob is one term, not a
+        # row set, and _cap_result_rows would have nothing to trim anyway.
+        store=lambda result: result,
+        log_label=f"get_term_info id={short_form}",
+    )
     try:
-        async with sem:
-            await tracker.leave_queue_start_work()
-            started = True
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(pool, _run_term_info, short_form, force_refresh)
-        log.info("get_term_info id=%s — done", short_form)
-        rcache.put(key, result)
-        await coalescer.remove(key)
-        fut.set_result(result)
-        return web.json_response(result)
+        return finish(await _shielded(task, budget))
+    except asyncio.TimeoutError:
+        return _computing_response(key, budget)
+    except Overloaded as exc:
+        return _overloaded_response(exc)
     except Exception as exc:
-        await coalescer.remove(key)
-        if not fut.done():
-            fut.set_exception(exc)
         return _failure_response(
             f"Query failed for id={short_form}", exc,
             f"get_term_info id={short_form}",
         )
-    finally:
-        # _abandon first, and synchronous: it is the one that must not be
-        # skipped if this finally is itself interrupted.
-        _abandon(coalescer, fut, key)
-        await tracker.finish_work(started=started)
 
 
 # Query functions that accept offset/limit paging (id ASC pages, <=10000 rows).
@@ -1104,6 +1112,83 @@ def _query_flag(request, name, default=False):
     if raw is None or not str(raw).strip():
         return default
     return str(raw).strip().lower() in _TRUE_VALUES
+
+
+#: Spellings of "no" a caller might reasonably write for a flag. Everything
+#: outside these two sets is neither yes nor no — it is a typo, and
+#: :func:`_flag_warning` says so instead of quietly meaning "no".
+_FALSE_VALUES = ("false", "0", "no", "off", "")
+
+
+def _flag_warning(request, name):
+    """Warn about a flag whose value is neither a yes nor a no, else ``None``.
+
+    ``_query_flag`` treats anything unrecognised as false, which is the right
+    *behaviour* — there is no third state to fall back to — but it is the wrong
+    thing to do in silence. ``include_graph=y`` and ``force_refresh=T`` read as
+    obviously affirmative to the person who typed them and mean "off" here, and
+    the response looks exactly like one where the flag was never passed.
+    """
+    raw = request.query.get(name)
+    if raw is None:
+        return None
+    value = str(raw).strip().lower()
+    if value in _TRUE_VALUES or value in _FALSE_VALUES:
+        return None
+    return ("%s=%r is not a recognised boolean and was read as false; use %s"
+            % (name, str(raw), " / ".join(_TRUE_VALUES)))
+
+
+def _suggest(name, known, cutoff=0.6, n=2):
+    """Closest matches for ``name`` among ``known``, best first."""
+    import difflib
+    return difflib.get_close_matches(str(name).lower(),
+                                     sorted({str(k).lower() for k in known}),
+                                     n=n, cutoff=cutoff)
+
+
+def _unknown_param_warnings(request, known):
+    """Warnings for query-string keys the handler does not read.
+
+    An ignored parameter is the quietest way an API can be wrong: the caller
+    gets a 200 that looks like an answer to the question they asked, and the
+    only clue that ``filter_type=Neuron`` should have been ``filter_types`` is
+    that the results are not filtered — which is indistinguishable from a
+    filter that matched everything. Naming the key back at them, with the near
+    miss where there is one, turns a wrong answer into a fixable one.
+
+    A warning rather than a 400 on purpose: rejecting unknown keys outright
+    would break every caller who appends a cache-buster or an analytics tag,
+    and this service already has clients in the wild.
+    """
+    if not known:
+        return []
+    seen, out = set(), []
+    for key in request.query.keys():
+        if key in known or key in seen:
+            continue
+        seen.add(key)
+        close = _suggest(key, known)
+        if close:
+            out.append("Ignored unrecognised parameter %r (did you mean %s?)"
+                       % (key, ", ".join(repr(c) for c in close)))
+        else:
+            out.append("Ignored unrecognised parameter %r" % (key,))
+    return out
+
+
+def _with_warnings(result, warnings):
+    """Append *warnings* to a result's ``warnings`` list, without mutating it.
+
+    The copy is not defensive style, it is required: results are shared out of
+    the cache by reference, so appending in place would attach one request's
+    warnings to every later request that hits the same key.
+    """
+    if not warnings or not isinstance(result, dict):
+        return result
+    merged = dict(result)
+    merged["warnings"] = list(merged.get("warnings") or []) + list(warnings)
+    return merged
 
 
 def _cap_result_rows(result, cap=None):
@@ -1221,6 +1306,13 @@ def _page_out(result, func_name, offset=0, page_size=None):
     return _slice_page(result, offset, page_size)
 
 
+#: Query-string keys /run_query reads. `query`, `type` and `max_depth` are the
+#: near misses this catches.
+_RUN_QUERY_PARAMS = frozenset({
+    "id", "query_type", "include_graph", "force_refresh", "offset", "limit",
+})
+
+
 async def handle_run_query(request):
     """GET /run_query?id=<short_form>&query_type=<QueryType>&include_graph=false"""
     short_form = request.query.get("id")
@@ -1245,20 +1337,73 @@ async def handle_run_query(request):
             {"error": "Missing required parameter: id"}, status=400
         )
 
-    include_graph = request.query.get("include_graph", "false").lower() in ("true", "1", "yes")
-    force_refresh = request.query.get("force_refresh", "false").lower() in ("true", "1", "yes")
+    include_graph = _query_flag(request, "include_graph")
+    force_refresh = _query_flag(request, "force_refresh")
+
+    warnings = _unknown_param_warnings(request, _RUN_QUERY_PARAMS)
+    for flag in ("include_graph", "force_refresh"):
+        warn = _flag_warning(request, flag)
+        if warn:
+            warnings.append(warn)
+
+    # `include_graph` is honoured by four of the forty query types. Asking for
+    # it on any of the other thirty-six used to return a graphless result that
+    # looked exactly like one where the flag had never been passed, which reads
+    # as "this query has no graph" when it means "this endpoint cannot draw one".
+    if include_graph and func_name not in _GRAPH_CONVERTERS:
+        warnings.append(
+            "include_graph is not supported for query_type=%s and was ignored; "
+            "graphs are available for: %s"
+            % (query_type,
+               ", ".join(sorted(qt for qt, fn in QUERY_TYPE_MAP.items()
+                                if fn in _GRAPH_CONVERTERS))))
+
+    # AllDatasets takes no id. Reading one and discarding it silently made
+    # `id=FBbt_00003748&query_type=AllDatasets` look like a filtered dataset
+    # list rather than the whole thing.
+    if func_name == "get_all_datasets" and short_form:
+        warnings.append(
+            "query_type=AllDatasets takes no id; %r was ignored" % (short_form,))
 
     rcache = request.app["result_cache"]
     coalescer = request.app["coalescer"]
+
     # Paging params — only consumed by PAGED_QUERY_FUNCS; harmless otherwise.
+    # Kept lenient (a bad value falls back to the default rather than 400ing —
+    # see _query_int) but no longer silent about it, because `limit=all` used to
+    # return one default-sized page with nothing to say it had not understood.
     def _int_param(name, default):
-        try:
-            return int(request.query.get(name, default))
-        except (TypeError, ValueError):
+        raw = request.query.get(name)
+        if raw is None:
             return default
-    offset = max(0, _int_param("offset", 0))
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            warnings.append(
+                "%s=%r is not an integer and was ignored (using %s)"
+                % (name, raw, default))
+            return default
+    offset = _int_param("offset", 0)
+    if offset < 0:
+        warnings.append("offset=%d is negative and was clamped to 0" % (offset,))
+        offset = 0
     limit = _int_param("limit", 0)  # 0/absent -> function default page size
+    if limit < 0:
+        warnings.append(
+            "limit=%d is negative and was ignored (using the default page size)"
+            % (limit,))
+        limit = 0
     page_size = limit if (limit and limit > 0) else RESULT_ROW_CAP
+
+    if (offset or limit) and func_name not in PAGED_QUERY_FUNCS:
+        warnings.append(
+            "query_type=%s does not page; offset/limit were ignored" % (query_type,))
+
+    def finish(result):
+        out = _page_out(result, func_name, offset, page_size)
+        if include_graph:
+            out = _maybe_add_graph(out, func_name, short_form)
+        return web.json_response(_with_warnings(out, warnings))
 
     # Normalize key — AllDatasets ignores the id parameter
     if func_name == "get_all_datasets":
@@ -1280,9 +1425,9 @@ async def handle_run_query(request):
         cached = rcache.get(key)
         if cached is not None:
             log.info("run_query id=%s query_type=%s — cache hit", short_form, query_type)
-            if include_graph:
-                cached = _maybe_add_graph(cached, func_name, short_form)
-            return web.json_response(_page_out(cached, func_name, offset, page_size))
+            return finish(cached)
+
+    budget = request.app.get("compute_budget", COMPUTE_BUDGET)
 
     # ---- Coalescing: piggyback on identical in-flight query ----
     fut, is_owner = await coalescer.get_or_create(key)
@@ -1291,10 +1436,9 @@ async def handle_run_query(request):
             "run_query id=%s query_type=%s — coalesced", short_form, query_type
         )
         try:
-            result = await fut
-            if include_graph:
-                result = _maybe_add_graph(result, func_name, short_form)
-            return web.json_response(_page_out(result, func_name, offset, page_size))
+            return finish(await _shielded(fut, budget))
+        except asyncio.TimeoutError:
+            return _computing_response(key, budget)
         except Overloaded as exc:
             return _overloaded_response(exc)
         except Exception as exc:
@@ -1318,50 +1462,38 @@ async def handle_run_query(request):
                                retry_after="30")
 
     # ---- Enter the bounded worker queue ----
-    pool = request.app["pool"]
-    sem = request.app["semaphore"]
-
-    await tracker.enter_queue()
     snap = tracker.snapshot
     log.info(
         "run_query id=%s query_type=%s — queued  (active=%d waiting=%d)",
         short_form, query_type, snap["active"], snap["waiting"],
     )
-    started = False
-    try:
-        async with sem:
-            await tracker.leave_queue_start_work()
-            started = True
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(
-                pool, _run_query, short_form, func_name, force_refresh, offset, limit
-            )
-        log.info("run_query id=%s query_type=%s — done", short_form, query_type)
-        # Bound/prepare for cache + coalesced sharing. AllAlignedImages caches a
-        # single server page; every other query caches its FULL set so any offset
-        # slice can be served (and later pages need no recompute).
+
+    # Bound/prepare for cache + coalesced sharing. AllAlignedImages caches a
+    # single server page; every other query caches its FULL set so any offset
+    # slice can be served (and later pages need no recompute). Coalesced waiters
+    # therefore receive the full set and slice their own page in `finish`.
+    def store(result):
         if func_name in PAGED_QUERY_FUNCS:
-            cached_result = _cap_result_rows(result)
-        else:
-            cached_result = _prepare_full_for_cache(result)
-        rcache.put(key, cached_result)
-        await coalescer.remove(key)
-        fut.set_result(cached_result)  # coalesced waiters slice their own page
-        out = _page_out(cached_result, func_name, offset, page_size)
-        if include_graph:
-            out = _maybe_add_graph(out, func_name, short_form)
-        return web.json_response(out)
+            return _cap_result_rows(result)
+        return _prepare_full_for_cache(result)
+
+    task = _spawn_compute(
+        request.app, coalescer, tracker, fut, key,
+        _run_query, (short_form, func_name, force_refresh, offset, limit),
+        store=store,
+        log_label=f"run_query id={short_form} query_type={query_type}",
+    )
+    try:
+        return finish(await _shielded(task, budget))
+    except asyncio.TimeoutError:
+        return _computing_response(key, budget)
+    except Overloaded as exc:
+        return _overloaded_response(exc)
     except Exception as exc:
-        await coalescer.remove(key)
-        if not fut.done():
-            fut.set_exception(exc)
         return _failure_response(
             f"Query failed for id={short_form} query_type={query_type}", exc,
             f"run_query id={short_form} query_type={query_type}",
         )
-    finally:
-        _abandon(coalescer, fut, key)
-        await tracker.finish_work(started=started)
 
 
 async def handle_health(request):
@@ -1434,7 +1566,125 @@ async def handle_status(request):
 # FlyBase & connectivity endpoint handlers
 # ---------------------------------------------------------------------------
 
-async def _dispatch_to_pool(request, cache_key, worker_fn, *args, post_fn=None):
+#: How long a request will wait for its own computation before answering 503
+#: and leaving the work running. See :func:`_dispatch_to_pool`. Set to 0 to
+#: disable the budget and wait indefinitely (the pre-1.22.36 behaviour).
+COMPUTE_BUDGET = float(os.getenv("VFBQUERY_COMPUTE_BUDGET", "180"))
+
+
+def _computing_response(cache_key, budget, retry_after="30"):
+    """503 for a query that outran its budget but is still being computed.
+
+    Deliberately not a 504 and not an error: nothing has failed. The work is
+    still running and will land in the cache, so the honest thing to tell the
+    caller is "not yet, ask again" — which is what 503 + Retry-After means.
+    """
+    log.info("compute budget of %.0fs exceeded for %s — still running",
+             budget, cache_key)
+    return web.json_response(
+        {"error": "Query exceeded the %.0fs response budget. It is still being "
+                  "computed and the result will be cached — retry shortly."
+                  % budget,
+         "status": "computing"},
+        status=503, headers={"Retry-After": retry_after})
+
+
+def _retrieve_task_exception(task):
+    """Done-callback that marks a detached task's exception as retrieved.
+
+    A task the handler stopped awaiting (budget expired, client hung up) has
+    nobody left to see its failure, and asyncio logs "Task exception was never
+    retrieved" at garbage-collection time — long after the fact and with no
+    request context. The failure is already recorded against the coalescer
+    future and the log inside :func:`_dispatch_to_pool`; this only silences the
+    duplicate.
+    """
+    if not task.cancelled():
+        task.exception()
+
+
+async def _shielded(awaitable, budget):
+    """Await *awaitable* under a time budget without cancelling it.
+
+    The shield is the whole point. ``asyncio.wait_for`` cancels what it is
+    waiting on when the timeout fires, which is exactly wrong here: the thing
+    being awaited is either the computation itself or the coalescing future
+    other requests are also waiting on, and neither belongs to the one client
+    who ran out of patience. Shielding separates "this request stops waiting"
+    from "this work stops running".
+
+    A falsy *budget* means wait indefinitely — still shielded, so a client
+    hanging up does not take the computation with it.
+    """
+    if not budget:
+        return await asyncio.shield(awaitable)
+    return await asyncio.wait_for(asyncio.shield(awaitable), budget)
+
+
+def _spawn_compute(app, coalescer, tracker, fut, cache_key, worker_fn, args,
+                   store=None, log_label=None):
+    """Run *worker_fn* as a task that owns the coalescer future and the cache.
+
+    Detaching the computation from the handler is what makes the compute budget
+    honest. Before this, the worker ran inline in the request coroutine, so a
+    client that hung up — or a proxy that gave up, or a handler that timed out —
+    cancelled it, and because ``CancelledError`` is a ``BaseException`` the work
+    died mid-flight with nothing written to the cache. The next caller started
+    the same minutes-long query from scratch, and so did the one after that.
+    Worse, every request coalesced onto the key was woken by ``_abandon`` with
+    "Request aborted, please retry" and pointed back at a query that had just
+    proved it takes longer than anyone was willing to wait.
+
+    As a task it outlives its caller, so :func:`_computing_response`'s "retry
+    shortly" means it: the retry finds the finished result in the cache. The
+    handler keeps only the *waiting*, which is the part that should be
+    cancellable.
+
+    *store* maps the worker's raw result to the value that gets cached and
+    handed to coalesced waiters; it defaults to :func:`_cap_result_rows`.
+    Handlers that page or decorate their response apply that to the stored
+    value afterwards, so the cache holds one canonical answer per key.
+    """
+    rcache = app["result_cache"]
+    pool = app["pool"]
+    sem = app["semaphore"]
+
+    async def _compute():
+        await tracker.enter_queue()
+        started = False
+        try:
+            async with sem:
+                await tracker.leave_queue_start_work()
+                started = True
+                loop = asyncio.get_event_loop()
+                result = await loop.run_in_executor(pool, worker_fn, *args)
+            result = store(result) if store is not None else _cap_result_rows(result)
+            rcache.put(cache_key, result)
+            await coalescer.remove(cache_key)
+            if not fut.done():
+                fut.set_result(result)
+            if log_label:
+                log.info("%s — done", log_label)
+            return result
+        except Exception as exc:
+            await coalescer.remove(cache_key)
+            if not fut.done():
+                fut.set_exception(exc)
+                fut.exception()          # see _shed: keeps asyncio quiet at GC
+            raise
+        finally:
+            # _abandon first, and synchronous: it is the one that must not be
+            # skipped if this finally is itself interrupted.
+            _abandon(coalescer, fut, cache_key)
+            await tracker.finish_work(started=started)
+
+    task = asyncio.ensure_future(_compute())
+    task.add_done_callback(_retrieve_task_exception)
+    return task
+
+
+async def _dispatch_to_pool(request, cache_key, worker_fn, *args, post_fn=None,
+                            known_params=None):
     """Shared dispatch logic for new endpoints — cache, coalesce, queue, run.
 
     If *post_fn* is given it is called on the result **after** cache
@@ -1444,23 +1694,42 @@ async def _dispatch_to_pool(request, cache_key, worker_fn, *args, post_fn=None):
     When the result comes from cache, *post_fn* runs in-process (no
     worker needed) because graph builders are lightweight CPU work plus
     a single Neo4j batch lookup.
+
+    *known_params* is the set of query-string keys the calling handler reads.
+    Anything else the caller sent is reported back as a warning rather than
+    ignored in silence — see :func:`_unknown_param_warnings`. It is applied
+    after the cache for the same reason *post_fn* is: the warning is a property
+    of the request, not of the answer, and must not be stored against a key
+    that does not include it.
+
+    The computation runs as its own task, **shielded** from the requesting
+    client. See :func:`_computing_response`.
     """
     rcache = request.app["result_cache"]
     coalescer = request.app["coalescer"]
 
+    warnings = _unknown_param_warnings(request, known_params)
+
+    def finish(result):
+        result = _cap_result_rows(result)
+        if warnings:
+            result = _with_warnings(result, warnings)
+        if post_fn is not None:
+            result = post_fn(result)
+        return web.json_response(result)
+
     cached = rcache.get(cache_key)
     if cached is not None:
-        if post_fn is not None:
-            cached = post_fn(cached)
-        return web.json_response(_cap_result_rows(cached))
+        return finish(cached)
+
+    budget = request.app.get("compute_budget", COMPUTE_BUDGET)
 
     fut, is_owner = await coalescer.get_or_create(cache_key)
     if not is_owner:
         try:
-            result = await fut
-            if post_fn is not None:
-                result = post_fn(result)
-            return web.json_response(_cap_result_rows(result))
+            return finish(await _shielded(fut, budget))
+        except asyncio.TimeoutError:
+            return _computing_response(cache_key, budget)
         except Overloaded as exc:
             return _overloaded_response(exc)
         except Exception as exc:
@@ -1475,31 +1744,16 @@ async def _dispatch_to_pool(request, cache_key, worker_fn, *args, post_fn=None):
                                "Server overloaded, please retry later",
                                retry_after="30")
 
-    pool = request.app["pool"]
-    sem = request.app["semaphore"]
-    await tracker.enter_queue()
-    started = False
+    task = _spawn_compute(request.app, coalescer, tracker, fut, cache_key,
+                          worker_fn, args)
     try:
-        async with sem:
-            await tracker.leave_queue_start_work()
-            started = True
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(pool, worker_fn, *args)
-        result = _cap_result_rows(result)
-        rcache.put(cache_key, result)
-        await coalescer.remove(cache_key)
-        fut.set_result(result)
-        if post_fn is not None:
-            result = post_fn(result)
-        return web.json_response(result)
+        return finish(await _shielded(task, budget))
+    except asyncio.TimeoutError:
+        return _computing_response(cache_key, budget)
+    except Overloaded as exc:
+        return _overloaded_response(exc)
     except Exception as exc:
-        await coalescer.remove(cache_key)
-        if not fut.done():
-            fut.set_exception(exc)
         return _failure_response("Query failed", exc, cache_key)
-    finally:
-        _abandon(coalescer, fut, cache_key)
-        await tracker.finish_work(started=started)
 
 
 async def handle_resolve_entity(request):
@@ -1510,7 +1764,8 @@ async def handle_resolve_entity(request):
         return web.json_response({"error": str(exc)}, status=400)
 
     return await _dispatch_to_pool(
-        request, f"resolve_entity:{query}", _run_resolve_entity, query
+        request, f"resolve_entity:{query}", _run_resolve_entity, query,
+        known_params=frozenset({"query"}),
     )
 
 
@@ -1523,6 +1778,7 @@ async def handle_find_stocks(request):
     return await _dispatch_to_pool(
         request, f"find_stocks:{feature_id}:{collection}",
         _run_find_stocks, feature_id, collection,
+        known_params=frozenset({"id", "collection"}),
     )
 
 
@@ -1534,7 +1790,8 @@ async def handle_resolve_combination(request):
         return web.json_response({"error": str(exc)}, status=400)
 
     return await _dispatch_to_pool(
-        request, f"resolve_combination:{query}", _run_resolve_combination, query
+        request, f"resolve_combination:{query}", _run_resolve_combination, query,
+        known_params=frozenset({"query"}),
     )
 
 
@@ -1546,6 +1803,7 @@ async def handle_find_combo_publications(request):
     return await _dispatch_to_pool(
         request, f"find_combo_publications:{fbco_id}",
         _run_find_combo_publications, fbco_id,
+        known_params=frozenset({"id"}),
     )
 
 
@@ -1553,7 +1811,147 @@ async def handle_list_connectome_datasets(request):
     """GET /list_connectome_datasets"""
     return await _dispatch_to_pool(
         request, "list_connectome_datasets", _run_list_connectome_datasets,
+        known_params=frozenset(),
     )
+
+
+# --------------------------------------------------------------------------- #
+# Connectome dataset vocabulary — what `exclude_dbs` is allowed to name.
+#
+# Same shape as _facet_vocabulary below (TTL, double-checked lock, fail open),
+# for the same reason: a validated parameter needs the real vocabulary, and a
+# validator that cannot reach it must let the request through rather than start
+# refusing valid input. The resolution itself reuses _xref_db_candidates, so
+# `exclude_dbs=flywire` and `db=flywire` mean the same thing on both endpoints
+# — one nickname algorithm, defined once, further down this file.
+# --------------------------------------------------------------------------- #
+
+#: How long the connectome dataset list is trusted. Datasets are added when VFB
+#: is rebuilt, never while the service is running.
+CONNECTOME_VOCAB_TTL = float(os.getenv("VFBQUERY_CONNECTOME_VOCAB_TTL", "3600"))
+
+#: How long a *failed* fetch is remembered — see FACET_VOCAB_FAIL_TTL.
+CONNECTOME_VOCAB_FAIL_TTL = 60.0
+
+#: Wall-clock bound on fetching the vocabulary. It is eight rows from Neo4j and
+#: it gates a request the caller is already waiting on, so a stalled fetch has
+#: to give up quickly and let the query run unvalidated.
+CONNECTOME_VOCAB_TIMEOUT = float(os.getenv("VFBQUERY_CONNECTOME_VOCAB_TIMEOUT", "20"))
+
+
+async def _connectome_vocabulary(app):
+    """The connectome datasets as ``[{label, symbol, short_form}, …]``.
+
+    Empty list is the fail-open signal — callers treat it as "do not validate",
+    never as "no dataset matches".
+    """
+    now = time.monotonic()
+    entry = app.get("connectome_vocab")
+    if entry and now - entry["fetched"] < entry["ttl"]:
+        return entry["values"]
+
+    lock = app.get("connectome_vocab_lock")
+    if lock is None:
+        lock = asyncio.Lock()
+        app["connectome_vocab_lock"] = lock
+
+    async with lock:
+        entry = app.get("connectome_vocab")
+        now = time.monotonic()
+        if entry and now - entry["fetched"] < entry["ttl"]:
+            return entry["values"]
+
+        values = []
+        ttl = CONNECTOME_VOCAB_FAIL_TTL
+        try:
+            loop = asyncio.get_event_loop()
+            values = await asyncio.wait_for(
+                loop.run_in_executor(app["pool"], _run_list_connectome_datasets),
+                CONNECTOME_VOCAB_TIMEOUT)
+            values = [v for v in (values or []) if isinstance(v, dict)]
+            if values:
+                ttl = CONNECTOME_VOCAB_TTL
+            else:
+                log.warning("connectome dataset list came back empty; "
+                            "exclude_dbs will not be validated")
+        except Exception as exc:                       # noqa: BLE001 — fail open
+            log.warning("connectome dataset list unavailable (%s: %s); "
+                        "exclude_dbs will not be validated",
+                        type(exc).__name__, exc)
+
+        app["connectome_vocab"] = {"values": values, "fetched": now, "ttl": ttl}
+        return values
+
+
+def _resolve_exclude_dbs(values, sites):
+    """Canonicalise ``exclude_dbs``, or raise :class:`BadParam` naming the typo.
+
+    The values reach Cypher as ``NOT s.short_form IN [...] AND NOT s.symbol[0]
+    IN [...]`` — an exact string comparison. So anything that is not letter-for
+    -letter a short_form or a symbol excluded **nothing**, and the caller got a
+    perfectly ordinary 200 whose only symptom was inflated counts:
+    ``exclude_dbs=hemibrain`` looks like it did what ``exclude_dbs=hb`` does and
+    silently double-counts instead. That is the same defect ``filter_types`` and
+    ``/xref``'s ``db`` already had, and it is closed the same way.
+
+    Each value is resolved against the live dataset list with
+    :func:`_xref_db_candidates`, so a symbol (``mc``), a short_form
+    (``male_cns_v0_9``), a label word (``male-cns``) or a whole label all
+    resolve to the same dataset.
+
+    Two properties worth preserving if this is ever rewritten:
+
+    * The canonical form is the dataset's **symbol**, which is what
+      ``DEFAULT_EXCLUDE_DBS`` already holds. So the default resolves to itself
+      and the existing cache keys keep working — no cache churn from shipping
+      this. Only spellings that were previously broken get new keys.
+    * Caller order is preserved rather than sorted, for the same reason:
+      ``[hb, fafb]`` must not become ``[fafb, hb]`` and orphan every cached
+      default answer.
+    """
+    values = [v for v in (values or []) if v]
+    if not values or not sites:
+        return list(values), []
+
+    resolved, seen, unknown = [], set(), {}
+    for value in values:
+        allowed = _xref_db_candidates(sites, value)
+        matched = [s for s in sites if _xref_matches_db(s, value, allowed)]
+        if not matched:
+            unknown[value] = _suggest(
+                value,
+                [n for s in sites for n in _xref_site_names(s) if n])
+            continue
+        for site in matched:
+            canon = site.get("symbol") or site.get("short_form") or site.get("label")
+            if canon and canon not in seen:
+                seen.add(canon)
+                resolved.append(canon)
+
+    if unknown:
+        parts = []
+        for name, suggestions in unknown.items():
+            if suggestions:
+                parts.append("%r (did you mean %s?)"
+                             % (name, ", ".join(repr(s) for s in suggestions)))
+            else:
+                parts.append("%r" % (name,))
+        raise BadParam(
+            "exclude_dbs: unknown dataset %s. GET /list_connectome_datasets "
+            "lists every dataset, by label, symbol and short_form."
+            % "; ".join(parts))
+
+    rewritten = [v for v in values if v not in resolved]
+    return resolved, rewritten
+
+
+#: Query-string keys /query_connectivity reads. Anything else is reported back
+#: rather than ignored — `exclude_db` and `min_weight` are the plausible near
+#: misses, and both used to return an unfiltered answer that looked filtered.
+_CONNECTIVITY_PARAMS = frozenset({
+    "upstream_type", "downstream_type", "weight", "group_by_class",
+    "exclude_dbs", "include_graph", "force_refresh",
+})
 
 
 async def handle_query_connectivity(request):
@@ -1564,6 +1962,13 @@ async def handle_query_connectivity(request):
     ``exclude_dbs`` defaults to ``DEFAULT_EXCLUDE_DBS`` (hemibrain and CATMAID
     FAFB, both of which double-count against datasets that are kept — see that
     constant for the reasoning); pass ``exclude_dbs=`` empty for all datasets.
+    Its values may be a symbol (``mc``), a short_form (``male_cns_v0_9``) or a
+    label (``male-cns``); an unrecognised one is a 400 with suggestions rather
+    than an exclusion that quietly excluded nothing.
+
+    The excluded datasets are echoed back as ``excluded_dbs`` so a caller can
+    see what the answer actually covers without re-deriving it from the query
+    string.
     """
     upstream = request.query.get("upstream_type") or None
     downstream = request.query.get("downstream_type") or None
@@ -1579,29 +1984,60 @@ async def handle_query_connectivity(request):
         weight = _query_int(request, "weight", 5, minimum=0)
     except BadParam as exc:
         return web.json_response({"error": str(exc)}, status=400)
-    group_by_class = request.query.get("group_by_class", "false").lower() in ("true", "1", "yes")
+    group_by_class = _query_flag(request, "group_by_class")
     exclude_dbs_raw = request.query.get("exclude_dbs")
     if exclude_dbs_raw is not None:
         exclude_dbs = [s.strip() for s in exclude_dbs_raw.split(",") if s.strip()]
     else:
         from .vfb_connectivity import DEFAULT_EXCLUDE_DBS
         exclude_dbs = list(DEFAULT_EXCLUDE_DBS)
-    include_graph = request.query.get("include_graph", "false").lower() in ("true", "1", "yes")
-    force_refresh = request.query.get("force_refresh", "false").lower() in ("true", "1", "yes")
+    include_graph = _query_flag(request, "include_graph")
+    force_refresh = _query_flag(request, "force_refresh")
 
-    post_fn = None
-    if include_graph:
-        def post_fn(result):
+    # Resolved before the cache key is built, so `exclude_dbs=male-cns` and
+    # `exclude_dbs=mc` share one entry instead of computing the same answer
+    # twice under two spellings.
+    warnings = []
+    if exclude_dbs:
+        try:
+            exclude_dbs, rewritten = _resolve_exclude_dbs(
+                exclude_dbs, await _connectome_vocabulary(request.app))
+        except BadParam as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+        if rewritten:
+            warnings.append(
+                "exclude_dbs %s resolved to %s"
+                % (", ".join(repr(v) for v in rewritten),
+                   ", ".join(repr(v) for v in exclude_dbs)))
+    for flag in ("group_by_class", "include_graph", "force_refresh"):
+        warn = _flag_warning(request, flag)
+        if warn:
+            warnings.append(warn)
+
+    def post_fn(result):
+        if not isinstance(result, dict):
+            return result
+        result = dict(result)            # shallow copy to avoid mutating cache
+        result["excluded_dbs"] = list(exclude_dbs)
+        if warnings:
+            result["warnings"] = list(result.get("warnings") or []) + warnings
+        if include_graph:
             from .graph_builder import graph_from_query_connectivity
-            conns = result.get("connections") if isinstance(result, dict) else None
+            conns = result.get("connections")
             if conns:
                 graph = graph_from_query_connectivity(
                     conns, group_by_class, upstream, downstream,
                 )
                 if graph is not None:
-                    result = dict(result)  # shallow copy to avoid mutating cache
                     result["graph"] = graph
-            return result
+            if "graph" not in result:
+                # Absent for two very different reasons — nothing to draw, or a
+                # builder that failed — and a missing key looked the same as
+                # `include_graph` never having been read at all.
+                result["warnings"] = list(result.get("warnings") or []) + [
+                    "include_graph was requested but no graph could be built "
+                    "(no connections matched, or the graph builder failed)."]
+        return result
 
     key = f"query_connectivity:{upstream}:{downstream}:{weight}:{group_by_class}:{exclude_dbs}"
     # force_refresh=true drops the in-memory L1 entry so the recomputed result
@@ -1611,8 +2047,13 @@ async def handle_query_connectivity(request):
     return await _dispatch_to_pool(
         request, key, _run_query_connectivity,
         upstream, downstream, weight, group_by_class, exclude_dbs, force_refresh,
-        post_fn=post_fn,
+        post_fn=post_fn, known_params=_CONNECTIVITY_PARAMS,
     )
+
+
+#: Query-string keys both hierarchy handlers read. `depth` and `relation` are
+#: the near misses this catches.
+_HIERARCHY_PARAMS = frozenset({"id", "relationship", "direction", "max_depth"})
 
 
 def _run_get_hierarchy(short_form, relationship, direction, max_depth):
@@ -1648,6 +2089,7 @@ async def handle_get_hierarchy(request):
     return await _dispatch_to_pool(
         request, key, _run_get_hierarchy,
         short_form, relationship, direction, max_depth,
+        known_params=_HIERARCHY_PARAMS,
     )
 
 
@@ -1681,10 +2123,28 @@ async def handle_get_hierarchy_html(request):
     json_response = await _dispatch_to_pool(
         request, key, _run_get_hierarchy,
         short_form, relationship, direction, max_depth,
+        known_params=_HIERARCHY_PARAMS,
     )
 
-    # Extract HTML from the JSON result
+    # A non-200 from the dispatch is a 503 or a 500 carrying its own
+    # explanation, not a tree. Parsing it for `html` and answering "No
+    # hierarchy data found" turned every one of those into a 404 about missing
+    # data — wrong status, wrong cause, and it hid the Retry-After that told the
+    # browser the answer was still being computed.
     import json as _json
+    if json_response.status != 200:
+        try:
+            detail = _json.loads(json_response.body).get("error", "")
+        except Exception:                              # noqa: BLE001
+            detail = ""
+        headers = {}
+        retry_after = json_response.headers.get("Retry-After")
+        if retry_after:
+            headers["Retry-After"] = retry_after
+        return web.Response(text="Error: %s" % (detail or "hierarchy unavailable"),
+                            status=json_response.status, headers=headers)
+
+    # Extract HTML from the JSON result
     result = _json.loads(json_response.body)
     html = result.get("html", "")
     if not html:
@@ -1968,12 +2428,20 @@ async def handle_facets(request):
         items = [(name, count) for name, count in items
                  if needle in _sc.normalise_facet_name(name)]
 
-    return web.json_response({
+    return web.json_response(_with_warnings({
         "count": len(items),
         "total": len(vocabulary),
         "contains": contains or None,
         "facets": [{"name": name, "docs": count} for name, count in items],
-    })
+    }, _unknown_param_warnings(request, frozenset({"contains"}))))
+
+
+#: Query-string keys /search reads. `q` is an accepted alias for `query`;
+#: `type`, `types` and `filter_type` are the near misses this catches.
+_SEARCH_PARAMS = frozenset({
+    "query", "q", "rows", "limit", "unique",
+    "filter_types", "exclude_types", "boost_types", "demote_types",
+})
 
 
 async def handle_search(request):
@@ -2023,19 +2491,43 @@ async def handle_search(request):
             {"error": "query must be at most %d characters" % MAX_QUERY_LEN},
             status=400)
 
+    warnings = _unknown_param_warnings(request, _SEARCH_PARAMS)
+    warn = _flag_warning(request, "unique")
+    if warn:
+        warnings.append(warn)
+
     try:
         rows = int(request.query.get("rows", _sc.DEFAULT_ROWS))
     except ValueError:
         return web.json_response({"error": "rows must be an integer"}, status=400)
-    rows = max(1, min(rows, _sc.MAX_ROWS))
+    # Clamped rather than rejected, but said out loud: `rows` is the size of the
+    # candidate set the comparator ranks, so silently changing it changes the
+    # *order* of the results, not just how many come back — a caller who asked
+    # for 5000 and got 1000 would otherwise have no way to know the top of their
+    # list was decided over a different pool than they specified.
+    if rows < 1 or rows > _sc.MAX_ROWS:
+        clamped = max(1, min(rows, _sc.MAX_ROWS))
+        warnings.append(
+            "rows=%d is outside 1..%d and was clamped to %d; rows sizes the "
+            "candidate set that gets ranked, so this affects ordering as well "
+            "as length" % (rows, _sc.MAX_ROWS, clamped))
+        rows = clamped
 
     limit_raw = request.query.get("limit")
     limit = None
     if limit_raw:
         try:
-            limit = max(0, int(limit_raw))
+            limit = int(limit_raw)
         except ValueError:
             return web.json_response({"error": "limit must be an integer"}, status=400)
+        # `limit=0` used to return `rows: []` alongside a non-zero `count` —
+        # a result set that says "1537 matches" and shows none of them. There is
+        # no sensible reading of "give me zero results", so say so rather than
+        # answering a question nobody asked.
+        if limit < 1:
+            return web.json_response(
+                {"error": "limit must be at least 1 (omit it for no limit)"},
+                status=400)
 
     unique = _query_flag(request, "unique")
 
@@ -2073,14 +2565,17 @@ async def handle_search(request):
     rcache = request.app["result_cache"]
     coalescer = request.app["coalescer"]
 
+    def finish(result):
+        return web.json_response(_with_warnings(_cap_result_rows(result), warnings))
+
     cached = rcache.get(cache_key)
     if cached is not None:
-        return web.json_response(_cap_result_rows(cached))
+        return finish(cached)
 
     fut, is_owner = await coalescer.get_or_create(cache_key)
     if not is_owner:
         try:
-            return web.json_response(_cap_result_rows(await fut))
+            return finish(await fut)
         except Overloaded as exc:
             return _overloaded_response(exc)
         except Exception as exc:
@@ -2141,7 +2636,7 @@ async def handle_search(request):
         stats["served"] += 1
         await coalescer.remove(cache_key)
         fut.set_result(result)
-        return web.json_response(result)
+        return finish(result)
     except Exception as exc:
         stats["failed"] += 1
         await coalescer.remove(cache_key)
@@ -2386,6 +2881,11 @@ async def _fetch_term_info_docs(session, ids):
     return out
 
 
+#: Query-string keys /xref reads. `site`, `database` and `dbs` are the near
+#: misses this catches.
+_XREF_PARAMS = frozenset({"id", "accession", "db"})
+
+
 async def handle_xref(request):
     """GET /xref?id=<VFB id>   |   GET /xref?accession=<external id>[&db=<site>]
 
@@ -2461,14 +2961,19 @@ async def handle_xref(request):
     rcache = request.app["result_cache"]
     coalescer = request.app["coalescer"]
 
+    warnings = _unknown_param_warnings(request, _XREF_PARAMS)
+
+    def finish(result):
+        return web.json_response(_with_warnings(_cap_result_rows(result), warnings))
+
     cached = rcache.get(cache_key)
     if cached is not None:
-        return web.json_response(_cap_result_rows(cached))
+        return finish(cached)
 
     fut, is_owner = await coalescer.get_or_create(cache_key)
     if not is_owner:
         try:
-            return web.json_response(_cap_result_rows(await fut))
+            return finish(await fut)
         except Overloaded as exc:
             return _overloaded_response(exc)
         except Exception as exc:
@@ -2567,7 +3072,7 @@ async def handle_xref(request):
         stats["served"] += 1
         await coalescer.remove(cache_key)
         fut.set_result(result)
-        return web.json_response(result)
+        return finish(result)
     except Exception as exc:
         stats["failed"] += 1
         await coalescer.remove(cache_key)
@@ -2827,7 +3332,13 @@ async def _search_payload(request, text):
     """Run one /search and shape it as a combinable table."""
     from . import search_config as _sc
 
-    key = "|".join(["search", text, str(_sc.DEFAULT_ROWS), "None", "", "", "", ""])
+    # Nine slots, in the same order as `handle_search`'s key. The eighth —
+    # `str(unique)` — was missing here, which meant a `search:` operand and a
+    # direct `/search` for the same text computed and stored the same answer
+    # under two different keys and never shared one. `unique` is False below,
+    # so this key now collides (correctly) with `/search?query=<text>`.
+    key = "|".join(["search", text, str(_sc.DEFAULT_ROWS), "None", str(False),
+                    "", "", "", ""])
     rcache = request.app["result_cache"]
     cached = rcache.get(key)
     if cached is not None:
@@ -2961,6 +3472,22 @@ async def handle_combine(request):
     except combine.CombineError as exc:
         return web.json_response({"error": str(exc)}, status=400)
 
+    # Reserved names are skipped above so they cannot be mistaken for operands.
+    # For the three that are reserved but not yet implemented that skip is the
+    # whole behaviour: the caller's `&offset=100` is neither an operand nor a
+    # page, and the response looked identical either way. Say which.
+    param_warnings = [
+        "%s is reserved but not implemented; it was ignored (it is refused as "
+        "an operand name so that implementing it later cannot silently change "
+        "what an existing expression means)" % name
+        for name in ("offset", "order_by", "force_refresh")
+        if query_params.get(name)
+    ]
+    for flag in ("explain_only", "require_complete"):
+        warn = _flag_warning(request, flag)
+        if warn:
+            param_warnings.append(warn)
+
     if not specs:
         return web.json_response({
             "error": "No operands given. Every name in the expression needs a "
@@ -2997,8 +3524,8 @@ async def handle_combine(request):
     # The whole point of the explanation is that a user can check the reading
     # *before* paying for the queries; explain_only makes that a request of its
     # own so a client can offer "what will this do?" as a button.
-    if query_params.get("explain_only", "").lower() in ("true", "1", "yes"):
-        return web.json_response({
+    if _query_flag(request, "explain_only"):
+        return web.json_response(_with_warnings({
             "expression": expr,
             "as_read": combine.to_expression(tree),
             "plain_english": combine.plain_english(
@@ -3006,15 +3533,14 @@ async def handle_combine(request):
             "operands": {n: specs[n]["raw"] for n in used},
             "unused_operands": unused,
             "universe_note": combine.UNIVERSE_NOTE,
-        })
+        }, param_warnings))
 
     try:
         limit = int(query_params.get("limit", 0) or 0)
     except ValueError:
         return web.json_response({"error": "limit must be an integer"},
                                  status=400)
-    require_complete = query_params.get("require_complete", "").lower() in (
-        "true", "1", "yes")
+    require_complete = _query_flag(request, "require_complete")
 
     # ---- run the operands ----
     # Concurrently: they are independent, and the alternative is that a
@@ -3037,7 +3563,7 @@ async def handle_combine(request):
     operands = {name: result for (name, _spec), result in zip(jobs, fetched)}
     universe_operand = operands.pop("universe", None)
 
-    warnings = []
+    warnings = list(param_warnings)
     for name in used:
         operand = operands[name]
         if not operand.by_id:

--- a/src/vfbquery/neo4j_client.py
+++ b/src/vfbquery/neo4j_client.py
@@ -65,11 +65,72 @@ RETRY_BACKOFF_S = 2.0
 #: path's patience — see :meth:`Neo4jConnect._probe`.
 CONNECTION_TEST_TIMEOUT_S = 15.0
 
+#: How long a single statement may run on the server, in seconds, regardless of
+#: how briefly this client intends to wait for it. See
+#: :func:`_execution_budget_ms`.
+SERVER_MAX_EXECUTION_S = 300.0
+
+#: A caller that has explicitly asked to wait longer than the ceiling gets this
+#: multiple of its own read timeout instead, so raising
+#: ``VFBQUERY_NEO4J_READ_TIMEOUT_S`` for a genuinely long analytical query still
+#: works.
+SERVER_BUDGET_FACTOR = 2.0
+
+#: Neo4j status codes that mean "the server stopped this itself". Retryable:
+#: the server says as much in the message it sends back.
+TERMINATED_CODES = (
+    "Neo.DatabaseError.Statement.ExecutionFailed",
+    "Neo.ClientError.Transaction.TransactionTimedOut",
+    "Neo.ClientError.Transaction.Terminated",
+)
+
 #: Transaction endpoints, newest first. VFB production speaks the first.
 V4_COMMIT_PATH = "/db/neo4j/tx/commit"
 V4_HEADERS = {'Content-type': 'application/json'}
 V3_COMMIT_PATH = "/db/data/transaction/commit"
 V3_HEADERS = {}
+
+
+def _is_terminated(response):
+    """True if this response is the server reporting it stopped the work itself."""
+    try:
+        errors = response.json().get('errors') or []
+    except ValueError:
+        return False
+    return any(e.get('code') in TERMINATED_CODES for e in errors)
+
+
+def _execution_budget_ms(read_timeout_s, factor=None, ceiling_s=None):
+    """Milliseconds to allow the *server* for a statement, as a header value.
+
+    A ``requests`` timeout only ends this side of the conversation. The
+    transaction it started keeps running on the database: measured here, a
+    query that took pdb.virtualflybrain.org down carried on after the client
+    had given up, and after the client process had been killed outright. So
+    every retry stacked another copy of the same expensive traversal onto a
+    server that was already struggling, which is how one bad query became an
+    hour-long outage.
+
+    Neo4j's HTTP API accepts ``max-execution-time`` (milliseconds) and
+    honours it: ``CALL apoc.util.sleep(6000)`` sent with
+    ``max-execution-time: 1000`` was killed after 2.16s with
+    ``Neo.DatabaseError.Statement.ExecutionFailed``. The documented
+    ``Neo4j-Transaction-Timeout`` header is ignored by this server — the same
+    sleep ran its full 6.18s — so it is not used.
+
+    The budget is a flat ceiling rather than something derived from the read
+    timeout. Deriving it was tried: at ``read_timeout + 5s`` and again at
+    ``read_timeout * 2``, legitimate connectivity queries that had always
+    passed started coming back as hard ``ExecutionFailed`` errors — 22 of them
+    in one run — because the client's patience is tuned for a healthy server
+    and these queries are simply slow. The ceiling exists to stop a runaway,
+    not to enforce a latency target, so it sits far above any query that
+    finishes. A caller who has explicitly asked to wait longer than the
+    ceiling gets ``factor`` times its own read timeout instead.
+    """
+    factor = SERVER_BUDGET_FACTOR if factor is None else factor
+    ceiling = SERVER_MAX_EXECUTION_S if ceiling_s is None else ceiling_s
+    return max(1000, int(max(read_timeout_s * factor, ceiling) * 1000))
 
 
 def dict_cursor(results):
@@ -123,6 +184,12 @@ class Neo4jConnect:
         self.connection_test_timeout = _env_float(
             "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S", CONNECTION_TEST_TIMEOUT_S
         )
+        self.server_budget_factor = _env_float(
+            "VFBQUERY_NEO4J_SERVER_BUDGET_FACTOR", SERVER_BUDGET_FACTOR
+        )
+        self.server_max_execution = _env_float(
+            "VFBQUERY_NEO4J_SERVER_MAX_EXECUTION_S", SERVER_MAX_EXECUTION_S
+        )
         self.commit = V4_COMMIT_PATH
         self.headers = dict(V4_HEADERS)
 
@@ -168,13 +235,25 @@ class Neo4jConnect:
 
         max_retries = getattr(self, "max_retries", MAX_RETRIES)
         delay = getattr(self, "retry_backoff", RETRY_BACKOFF_S)
+
+        # Bound the work on the server too, not just the wait on this side —
+        # see _execution_budget_ms.
+        headers = dict(self.headers)
+        headers["max-execution-time"] = str(
+            _execution_budget_ms(
+                self.read_timeout,
+                getattr(self, "server_budget_factor", SERVER_BUDGET_FACTOR),
+                getattr(self, "server_max_execution", SERVER_MAX_EXECUTION_S),
+            )
+        )
+
         for attempt in range(max_retries + 1):
             try:
                 response = requests.post(
                     url=f"{self.base_uri}{self.commit}",
                     auth=(self.usr, self.pwd),
                     data=json.dumps(payload),
-                    headers=self.headers,
+                    headers=headers,
                     timeout=(self.connect_timeout, self.read_timeout),
                 )
             except requests.exceptions.RequestException as e:
@@ -196,6 +275,22 @@ class Neo4jConnect:
 
             if self.rest_return_check(response):
                 return response.json()['results']
+
+            # A statement the server stopped is the same kind of event as a
+            # read that timed out on this side — the work ran long, not wrong —
+            # so it gets the same treatment. Without this the two paths
+            # disagreed: an overrun caught by the client retried and usually
+            # succeeded, while an overrun caught by the server returned False
+            # on the first attempt.
+            if attempt < max_retries and _is_terminated(response):
+                print(
+                    f"Query terminated by the server; retrying in {delay:.0f}s "
+                    f"(attempt {attempt + 2} of {max_retries + 1})..."
+                )
+                time.sleep(delay)
+                delay *= 2
+                continue
+
             return False
 
         return False
@@ -234,13 +329,22 @@ class Neo4jConnect:
         1`` answers the only question being asked.
         """
         cap = getattr(self, "connection_test_timeout", CONNECTION_TEST_TIMEOUT_S)
-        timeout = (min(self.connect_timeout, cap), min(self.read_timeout, cap))
+        read = min(self.read_timeout, cap)
+        timeout = (min(self.connect_timeout, cap), read)
+        probe_headers = dict(headers)
+        probe_headers["max-execution-time"] = str(
+            _execution_budget_ms(
+                read,
+                getattr(self, "server_budget_factor", SERVER_BUDGET_FACTOR),
+                getattr(self, "server_max_execution", SERVER_MAX_EXECUTION_S),
+            )
+        )
         try:
             response = requests.post(
                 url=f"{self.base_uri}{commit_path}",
                 auth=(self.usr, self.pwd),
                 data=json.dumps({'statements': [{'statement': 'RETURN 1'}]}),
-                headers=headers,
+                headers=probe_headers,
                 timeout=timeout,
             )
         except requests.exceptions.RequestException as e:

--- a/src/vfbquery/neo4j_client.py
+++ b/src/vfbquery/neo4j_client.py
@@ -8,9 +8,58 @@ that come with the full vfb_connect package.
 Based on vfb_connect.neo.neo4j_tools.Neo4jConnect
 """
 
+import os
 import requests
 import json
 import time
+
+
+def _env_float(name, default):
+    """Read a float from the environment, ignoring anything unparseable."""
+    try:
+        return float(os.environ.get(name, "") or default)
+    except (TypeError, ValueError):
+        return default
+
+
+#: Seconds to wait for the TCP connect. Short: an unreachable host should fail
+#: immediately rather than sit in the pool.
+CONNECT_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECT_TIMEOUT_S", 10.0)
+
+#: Seconds to wait for the *first byte* of a response. This is the number that
+#: keeps a stalled server from hanging a caller forever.
+#:
+#: ``requests`` defaults to no timeout at all, which means a socket that is open
+#: but silent blocks the calling thread indefinitely. pdb.virtualflybrain.org
+#: does exactly that under load — it accepts the connection and then returns
+#: nothing for minutes — so without this a single blip turns a seven-minute CI
+#: job into one that is still running when the runner's two-hour ceiling kills
+#: it. Raise it with ``VFBQUERY_NEO4J_READ_TIMEOUT_S`` for a genuinely long
+#: analytical query; lower it in CI to fail fast.
+READ_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_READ_TIMEOUT_S", 120.0)
+
+#: How many times a request is retried after a connection-level failure.
+#:
+#: This used to be unbounded: the exception handler slept ten seconds and
+#: re-entered ``commit_list`` recursively, so a server that was down stayed in
+#: that loop until something else killed the process (and grew the Python stack
+#: one frame per attempt while it did). Retrying is still right — the endpoint
+#: does drop the occasional connection — but it has to end.
+MAX_RETRIES = int(_env_float("VFBQUERY_NEO4J_MAX_RETRIES", 3))
+
+#: Seconds to wait before the first retry; doubled for each subsequent one.
+RETRY_BACKOFF_S = _env_float("VFBQUERY_NEO4J_RETRY_BACKOFF_S", 2.0)
+
+#: Ceiling for the connection test run during construction. It only decides
+#: which transaction API the server speaks, so it must not inherit the query
+#: path's patience — see :meth:`Neo4jConnect._probe`.
+CONNECTION_TEST_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S", 15.0)
+
+#: Transaction endpoints, newest first. VFB production speaks the first.
+V4_COMMIT_PATH = "/db/neo4j/tx/commit"
+V4_HEADERS = {'Content-type': 'application/json'}
+V3_COMMIT_PATH = "/db/data/transaction/commit"
+V3_HEADERS = {}
 
 
 def dict_cursor(results):
@@ -40,23 +89,44 @@ class Neo4jConnect:
     :param pwd: password for authentication
     """
     
-    def __init__(self, 
+    def __init__(self,
                  endpoint: str = "http://pdb.virtualflybrain.org",
                  usr: str = "neo4j",
-                 pwd: str = "vfb"):
+                 pwd: str = "vfb",
+                 connect_timeout: float = None,
+                 read_timeout: float = None):
         self.base_uri = endpoint
         self.usr = usr
         self.pwd = pwd
-        self.commit = "/db/neo4j/tx/commit"
-        self.headers = {'Content-type': 'application/json'}
-        
-        # Test connection and fall back to v3 API if needed
-        if not self.test_connection():
+        self.connect_timeout = (CONNECT_TIMEOUT_S if connect_timeout is None
+                                else connect_timeout)
+        self.read_timeout = (READ_TIMEOUT_S if read_timeout is None
+                             else read_timeout)
+        self.max_retries = MAX_RETRIES
+        self.commit = V4_COMMIT_PATH
+        self.headers = dict(V4_HEADERS)
+
+        # Work out which transaction API this server speaks. Only a definitive
+        # negative answer — the server replied, and said no — is grounds for
+        # falling back to v3. A timeout is not an answer: the server being slow
+        # says nothing about which API it speaks, and treating it as a "no" used
+        # to send construction down the v3 path and then raise, so a transient
+        # stall failed the caller outright instead of letting the query's own
+        # bounded retry ride it out.
+        status = self._probe(V4_COMMIT_PATH, V4_HEADERS)
+        if status == "wrong-api":
             print("Falling back to Neo4j v3 connection")
-            self.commit = "/db/data/transaction/commit"
-            self.headers = {}
-            if not self.test_connection():
+            if self._probe(V3_COMMIT_PATH, V3_HEADERS) == "ok":
+                self.commit = V3_COMMIT_PATH
+                self.headers = dict(V3_HEADERS)
+            else:
                 raise Exception("Failed to connect to Neo4j.")
+        elif status == "unreachable":
+            print(
+                f"\033[33mWarning:\033[0m {self.base_uri} did not answer within "
+                f"{min(self.connect_timeout, CONNECTION_TEST_TIMEOUT_S):.0f}s; "
+                "assuming the Neo4j 4+ transaction API and continuing."
+            )
     
     def commit_list(self, statements, return_graphs=False):
         """
@@ -75,24 +145,40 @@ class Neo4jConnect:
                 cstatements.append({'statement': s})
         
         payload = {'statements': cstatements}
-        
-        try:
-            response = requests.post(
-                url=f"{self.base_uri}{self.commit}",
-                auth=(self.usr, self.pwd),
-                data=json.dumps(payload),
-                headers=self.headers
-            )
-        except requests.exceptions.RequestException as e:
-            print(f"\033[31mConnection Error:\033[0m {e}")
-            print("Retrying in 10 seconds...")
-            time.sleep(10)
-            return self.commit_list(statements)
-        
-        if self.rest_return_check(response):
-            return response.json()['results']
-        else:
+
+        max_retries = getattr(self, "max_retries", MAX_RETRIES)
+        delay = RETRY_BACKOFF_S
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.post(
+                    url=f"{self.base_uri}{self.commit}",
+                    auth=(self.usr, self.pwd),
+                    data=json.dumps(payload),
+                    headers=self.headers,
+                    timeout=(self.connect_timeout, self.read_timeout),
+                )
+            except requests.exceptions.RequestException as e:
+                if attempt >= max_retries:
+                    print(f"\033[31mConnection Error:\033[0m {e}")
+                    print(
+                        f"Giving up after {max_retries + 1} attempt(s) "
+                        f"(read timeout {self.read_timeout}s)."
+                    )
+                    return False
+                print(f"\033[31mConnection Error:\033[0m {e}")
+                print(
+                    f"Retrying in {delay:.0f}s "
+                    f"(attempt {attempt + 2} of {max_retries + 1})..."
+                )
+                time.sleep(delay)
+                delay *= 2
+                continue
+
+            if self.rest_return_check(response):
+                return response.json()['results']
             return False
+
+        return False
     
     def rest_return_check(self, response):
         """
@@ -113,10 +199,43 @@ class Neo4jConnect:
             else:
                 return True
     
+    def _probe(self, commit_path, headers):
+        """Ask one transaction endpoint whether it is there and speaks Cypher.
+
+        Returns ``"ok"``, ``"wrong-api"`` (the server answered, and the answer
+        was no) or ``"unreachable"`` (it did not answer in time). Keeping those
+        two failures apart is the whole point: only the first is a reason to
+        try a different endpoint.
+
+        This runs on every construction, so it must not inherit the query
+        path's patience or its retries — with those, a stalled server would
+        cost minutes here, twice, before the caller saw a real query. It also
+        no longer scans for a node (``MATCH (n) RETURN n LIMIT 1``); ``RETURN
+        1`` answers the only question being asked.
+        """
+        timeout = (min(self.connect_timeout, CONNECTION_TEST_TIMEOUT_S),
+                   min(self.read_timeout, CONNECTION_TEST_TIMEOUT_S))
+        try:
+            response = requests.post(
+                url=f"{self.base_uri}{commit_path}",
+                auth=(self.usr, self.pwd),
+                data=json.dumps({'statements': [{'statement': 'RETURN 1'}]}),
+                headers=headers,
+                timeout=timeout,
+            )
+        except requests.exceptions.RequestException as e:
+            print(f"\033[31mConnection Error:\033[0m {e}")
+            return "unreachable"
+
+        if response.status_code != 200:
+            print(f"\033[31mConnection Error:\033[0m "
+                  f"{response.status_code} ({response.reason})")
+            return "wrong-api"
+        try:
+            return "wrong-api" if response.json().get('errors') else "ok"
+        except ValueError:
+            return "wrong-api"
+
     def test_connection(self):
-        """Test neo4j endpoint connection"""
-        statements = ["MATCH (n) RETURN n LIMIT 1"]
-        if self.commit_list(statements):
-            return True
-        else:
-            return False
+        """True if the endpoint this instance is bound to answers ``RETURN 1``."""
+        return self._probe(self.commit, self.headers) == "ok"

--- a/src/vfbquery/neo4j_client.py
+++ b/src/vfbquery/neo4j_client.py
@@ -22,9 +22,19 @@ def _env_float(name, default):
         return default
 
 
+#: Every setting below is a *fallback*, used only when the corresponding
+#: environment variable is unset. They are resolved in :meth:`Neo4jConnect.__init__`,
+#: not at import time, and that distinction matters: ``src/__init__.py`` does
+#: ``from vfbquery import *``, so importing anything under ``src.test`` imports
+#: this module first. Frozen-at-import constants meant a test package could not
+#: set its own timeouts — the values were already read — and the conda job kept
+#: the REPL-tuned defaults no matter what the suite asked for. Reading at
+#: construction also makes the settings genuinely live: change the environment
+#: and the next connection picks it up.
+
 #: Seconds to wait for the TCP connect. Short: an unreachable host should fail
 #: immediately rather than sit in the pool.
-CONNECT_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECT_TIMEOUT_S", 10.0)
+CONNECT_TIMEOUT_S = 10.0
 
 #: Seconds to wait for the *first byte* of a response. This is the number that
 #: keeps a stalled server from hanging a caller forever.
@@ -36,7 +46,7 @@ CONNECT_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECT_TIMEOUT_S", 10.0)
 #: job into one that is still running when the runner's two-hour ceiling kills
 #: it. Raise it with ``VFBQUERY_NEO4J_READ_TIMEOUT_S`` for a genuinely long
 #: analytical query; lower it in CI to fail fast.
-READ_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_READ_TIMEOUT_S", 120.0)
+READ_TIMEOUT_S = 120.0
 
 #: How many times a request is retried after a connection-level failure.
 #:
@@ -45,15 +55,15 @@ READ_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_READ_TIMEOUT_S", 120.0)
 #: that loop until something else killed the process (and grew the Python stack
 #: one frame per attempt while it did). Retrying is still right — the endpoint
 #: does drop the occasional connection — but it has to end.
-MAX_RETRIES = int(_env_float("VFBQUERY_NEO4J_MAX_RETRIES", 3))
+MAX_RETRIES = 3
 
 #: Seconds to wait before the first retry; doubled for each subsequent one.
-RETRY_BACKOFF_S = _env_float("VFBQUERY_NEO4J_RETRY_BACKOFF_S", 2.0)
+RETRY_BACKOFF_S = 2.0
 
 #: Ceiling for the connection test run during construction. It only decides
 #: which transaction API the server speaks, so it must not inherit the query
 #: path's patience — see :meth:`Neo4jConnect._probe`.
-CONNECTION_TEST_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S", 15.0)
+CONNECTION_TEST_TIMEOUT_S = 15.0
 
 #: Transaction endpoints, newest first. VFB production speaks the first.
 V4_COMMIT_PATH = "/db/neo4j/tx/commit"
@@ -98,11 +108,21 @@ class Neo4jConnect:
         self.base_uri = endpoint
         self.usr = usr
         self.pwd = pwd
-        self.connect_timeout = (CONNECT_TIMEOUT_S if connect_timeout is None
-                                else connect_timeout)
-        self.read_timeout = (READ_TIMEOUT_S if read_timeout is None
-                             else read_timeout)
-        self.max_retries = MAX_RETRIES
+        # Resolved here, not at import time — see the note above the constants.
+        # An explicit argument still wins over the environment.
+        self.connect_timeout = (
+            _env_float("VFBQUERY_NEO4J_CONNECT_TIMEOUT_S", CONNECT_TIMEOUT_S)
+            if connect_timeout is None else connect_timeout
+        )
+        self.read_timeout = (
+            _env_float("VFBQUERY_NEO4J_READ_TIMEOUT_S", READ_TIMEOUT_S)
+            if read_timeout is None else read_timeout
+        )
+        self.max_retries = int(_env_float("VFBQUERY_NEO4J_MAX_RETRIES", MAX_RETRIES))
+        self.retry_backoff = _env_float("VFBQUERY_NEO4J_RETRY_BACKOFF_S", RETRY_BACKOFF_S)
+        self.connection_test_timeout = _env_float(
+            "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S", CONNECTION_TEST_TIMEOUT_S
+        )
         self.commit = V4_COMMIT_PATH
         self.headers = dict(V4_HEADERS)
 
@@ -124,7 +144,7 @@ class Neo4jConnect:
         elif status == "unreachable":
             print(
                 f"\033[33mWarning:\033[0m {self.base_uri} did not answer within "
-                f"{min(self.connect_timeout, CONNECTION_TEST_TIMEOUT_S):.0f}s; "
+                f"{min(self.connect_timeout, self.connection_test_timeout):.0f}s; "
                 "assuming the Neo4j 4+ transaction API and continuing."
             )
     
@@ -147,7 +167,7 @@ class Neo4jConnect:
         payload = {'statements': cstatements}
 
         max_retries = getattr(self, "max_retries", MAX_RETRIES)
-        delay = RETRY_BACKOFF_S
+        delay = getattr(self, "retry_backoff", RETRY_BACKOFF_S)
         for attempt in range(max_retries + 1):
             try:
                 response = requests.post(
@@ -213,8 +233,8 @@ class Neo4jConnect:
         no longer scans for a node (``MATCH (n) RETURN n LIMIT 1``); ``RETURN
         1`` answers the only question being asked.
         """
-        timeout = (min(self.connect_timeout, CONNECTION_TEST_TIMEOUT_S),
-                   min(self.read_timeout, CONNECTION_TEST_TIMEOUT_S))
+        cap = getattr(self, "connection_test_timeout", CONNECTION_TEST_TIMEOUT_S)
+        timeout = (min(self.connect_timeout, cap), min(self.read_timeout, cap))
         try:
             response = requests.post(
                 url=f"{self.base_uri}{commit_path}",

--- a/src/vfbquery/solr_result_cache.py
+++ b/src/vfbquery/solr_result_cache.py
@@ -1140,7 +1140,29 @@ def with_solr_cache(query_type: str):
                 import inspect
                 func_takes_limit = 'limit' in inspect.signature(func).parameters
 
-                if func_takes_limit:
+                # Computing the full result is only worth doing if we can then
+                # store it. In read-only mode we cannot, so the extra work buys
+                # nothing and is charged entirely to the caller — who asked for
+                # ten rows and gets billed for all of them.
+                #
+                # That is not a theoretical cost. ``expression_overlaps_here``
+                # walks an unbounded ``has_source|SUBCLASSOF|INSTANCEOF`` path
+                # that reaches 100,426 individuals for FBbt_00007228: with the
+                # caller's ``limit=10`` it answers in about six seconds, and at
+                # ``limit=-1`` it does not finish at all. PR checks run with
+                # ``VFBQUERY_CACHE_READONLY=true`` and so can never warm the
+                # cache, which meant every PR paid the uncapped price forever
+                # and one of those runs took production Neo4j down for an hour.
+                honour_callers_limit = (
+                    func_takes_limit and not should_cache and solr_caching_readonly()
+                )
+                if honour_callers_limit:
+                    logger.debug(
+                        f"Cache is read-only; running {query_type}({term_id}) at the "
+                        f"caller's limit={limit} rather than computing the full result"
+                    )
+
+                if func_takes_limit and not honour_callers_limit:
                     # Always compute the full result so we have something
                     # complete to cache. If the caller already asked for
                     # the full result (should_cache=True), this is the same
@@ -1151,8 +1173,15 @@ def with_solr_cache(query_type: str):
                     if _func_takes_offset:
                         full_kwargs['offset'] = 0
                     full_result = _call(*args, **full_kwargs)
+                    result_is_full = True
                 else:
                     full_result = _call(*args, **kwargs)
+                    # Only a full result may be written under the limit=-1
+                    # cache key. A function with no limit parameter always
+                    # returns one; a call made at the caller's own limit does
+                    # not, and caching it would serve a truncated table to
+                    # every later reader as if it were complete.
+                    result_is_full = not honour_callers_limit
 
                 # Validate the full result before caching.
                 full_is_valid = False
@@ -1169,7 +1198,7 @@ def with_solr_cache(query_type: str):
                     else:
                         full_is_valid = True
 
-                if full_is_valid:
+                if full_is_valid and result_is_full:
                     try:
                         full_kwargs_for_cache = kwargs.copy()
                         full_kwargs_for_cache['limit'] = -1
@@ -1182,7 +1211,10 @@ def with_solr_cache(query_type: str):
                 # Return what the caller asked for: full result if
                 # should_cache, else slice the full result to the requested
                 # limit. The slicing mirrors the non-expensive branch below.
-                if should_cache or limit == -1 or full_result is None:
+                # Nothing to slice when the function was already given the
+                # caller's limit — slicing again would apply the offset twice.
+                if (should_cache or limit == -1 or full_result is None
+                        or not result_is_full):
                     result = full_result
                 else:
                     result = full_result

--- a/src/vfbquery/solr_result_cache.py
+++ b/src/vfbquery/solr_result_cache.py
@@ -77,6 +77,72 @@ def _decode_cache_field(cached_field) -> str:
     return cached_field
 
 
+
+# --- Cache namespaces -------------------------------------------------------
+# Every cache document id is "<prefix>vfb_query_<query_type>_<term_id>". In
+# production the prefix is empty, which is what makes the deployed service and
+# the released package share one warm cache.
+#
+# CI needs something different. A PR check must never write into that shared
+# cache (experimental code would poison it for the live site), but running with
+# the cache switched off entirely means every job pays full cold-query cost —
+# tens of minutes of Neo4j/Owlery work per run, and perf assertions that grade
+# a cold path nobody in production ever takes.
+#
+# VFBQUERY_CACHE_NAMESPACE resolves that: it moves *all* reads, writes and
+# deletes for this process into a private id prefix. Experimental code can then
+# write freely, because it is physically incapable of addressing a production
+# document. Set it per branch (e.g. "ci-fix-connectivity") so one branch's
+# results can never be served to another's tests.
+#
+# VFBQUERY_CACHE_NAMESPACE_FALLBACK adds a read-through: on a namespace miss,
+# read the production document instead (never writing or purging it). That
+# makes a brand-new namespace warm on its very first run. Use it for timing
+# tests, where a production entry is a fair stand-in; leave it off for
+# correctness tests, where reading production would hide the branch's own
+# behaviour behind an entry produced by different code.
+
+_NAMESPACE_SEPARATOR = "__"
+
+
+def cache_namespace() -> str:
+    """The private cache namespace for this process ('' means production).
+
+    Sanitised to ``[a-z0-9_]`` because the id lands unescaped in a Solr ``q=id:``
+    term, where characters like ``-``, ``:`` and whitespace change the query's
+    meaning rather than matching literally. A branch name is therefore a safe
+    thing to pass in. Evaluated per call so tests can toggle it via env.
+    """
+    raw = (os.getenv('VFBQUERY_CACHE_NAMESPACE', '') or '').strip().lower()
+    if not raw:
+        return ''
+    return re.sub(r'[^a-z0-9]+', '_', raw).strip('_')[:48]
+
+
+def cache_namespace_fallback() -> bool:
+    """True when a namespace miss should fall back to reading production."""
+    return os.getenv('VFBQUERY_CACHE_NAMESPACE_FALLBACK', 'false').lower() in (
+        'true', '1', 'yes', 'on')
+
+
+def cache_doc_id_for(query_type: str, term_id: str, namespace: Optional[str] = None) -> str:
+    """Cache document id for a query, in the given namespace (None = current)."""
+    ns = cache_namespace() if namespace is None else namespace
+    prefix = f"ns_{ns}{_NAMESPACE_SEPARATOR}" if ns else ""
+    return f"{prefix}vfb_query_{query_type}_{term_id}"
+
+
+def cache_doc_glob(namespace: Optional[str] = None) -> str:
+    """Solr id wildcard matching every cache document in a namespace.
+
+    Note the production glob ``id:vfb_query_*`` does not match namespaced ids
+    (they start ``ns_``), so the production cleanup sweep and stats report leave
+    CI documents alone — and vice versa.
+    """
+    ns = cache_namespace() if namespace is None else namespace
+    return f"ns_{ns}{_NAMESPACE_SEPARATOR}vfb_query_*" if ns else "vfb_query_*"
+
+
 @dataclass 
 class CacheMetadata:
     """Metadata for cached results"""
@@ -122,6 +188,19 @@ class SolrResultCache:
         if cache_url is None:
             cache_url = os.getenv('VFBQUERY_SOLR_URL', self.DEFAULT_CACHE_URL)
         self.cache_url = cache_url
+        # A namespaced (CI) cache is scratch space in the same Solr collection
+        # as production, so it gets a much shorter default life: long enough to
+        # warm a re-run or a follow-up push, short enough that abandoned branches
+        # evaporate instead of accumulating. VFBQUERY_CACHE_TTL_HOURS overrides
+        # either default.
+        raw_ttl = os.getenv('VFBQUERY_CACHE_TTL_HOURS')
+        if raw_ttl:
+            try:
+                ttl_hours = int(raw_ttl)
+            except ValueError:
+                logger.warning("Invalid VFBQUERY_CACHE_TTL_HOURS=%r; ignoring", raw_ttl)
+        elif cache_namespace():
+            ttl_hours = 48
         self.ttl_hours = ttl_hours
         if max_result_size_mb is None:
             raw = os.getenv("VFBQUERY_MAX_RESULT_MB", "100")
@@ -142,6 +221,19 @@ class SolrResultCache:
         self._solr_disabled_until = 0.0  # epoch timestamp
         self._solr_backoff_seconds = int(os.getenv('VFBQUERY_SOLR_BACKOFF_SECONDS', '60'))
         self._solr_last_error = None
+
+        # Loud on purpose. A namespace set by accident on a production deploy
+        # would look like a total cache wipe (every lookup missing, every query
+        # cold) with nothing in the logs to explain it.
+        _ns = cache_namespace()
+        if _ns:
+            logger.warning(
+                "SOLR result cache is namespaced as '%s' (ids prefixed 'ns_%s%s'); "
+                "production cache entries will not be read%s, written or deleted. "
+                "TTL %sh.",
+                _ns, _ns, _NAMESPACE_SEPARATOR,
+                " (except read-only fallback, which is ON)" if cache_namespace_fallback() else "",
+                self.ttl_hours)
 
     @property
     def solr_cache_enabled(self) -> bool:
@@ -268,8 +360,32 @@ class SolrResultCache:
         return False
 
     def get_cached_result(self, query_type: str, term_id: str, **params) -> Optional[Any]:
+        """Retrieve a cached result, honouring the configured cache namespace.
+
+        In production (no namespace) this is a single lookup, exactly as before.
+        With VFBQUERY_CACHE_NAMESPACE set, the private document is tried first;
+        only if it misses and VFBQUERY_CACHE_NAMESPACE_FALLBACK is on do we read
+        the production document, and then strictly read-only — a namespaced
+        process never purges, rewrites or expires a production entry.
+        """
+        namespace = cache_namespace()
+        result = self._get_cached_result_in(namespace, True, query_type, term_id, **params)
+        if result is None and namespace and cache_namespace_fallback():
+            result = self._get_cached_result_in('', False, query_type, term_id, **params)
+            if result is not None:
+                logger.debug(
+                    "Namespace '%s' miss for %s(%s); served from production cache",
+                    namespace, query_type, term_id)
+        return result
+
+    def _get_cached_result_in(self, namespace: str, allow_purge: bool,
+                              query_type: str, term_id: str, **params) -> Optional[Any]:
         """
         Retrieve cached result from separate cache document
+
+        ``allow_purge`` is False when reading outside our own namespace: the
+        version/expiry/corruption checks still reject an unusable entry, but they
+        must not delete it, because it belongs to somebody else.
         
         Args:
             query_type: Type of query ('term_info', 'instances', etc.)
@@ -285,8 +401,9 @@ class SolrResultCache:
         try:
             # Query for cache document with prefixed ID including query type
             # This ensures different query types for the same term have separate cache entries
-            cache_doc_id = f"vfb_query_{query_type}_{term_id}"
-            
+            cache_doc_id = cache_doc_id_for(query_type, term_id, namespace)
+            purge = self._clear_expired_cache_document if allow_purge else (lambda _id: None)
+
             response = requests.get(f"{self.cache_url}/select", params={
                 "q": f"id:{cache_doc_id}",
                 "fl": "cache_data",
@@ -320,7 +437,7 @@ class SolrResultCache:
                 cached_data = json.loads(_decode_cache_field(cached_field))
             except (ValueError, TypeError):
                 logger.warning(f"Corrupt cache entry for {query_type}({term_id}); clearing it")
-                self._clear_expired_cache_document(cache_doc_id)
+                purge(cache_doc_id)
                 return None
             
             # Check package version before anything else so stale cache is rejected early.
@@ -346,7 +463,7 @@ class SolrResultCache:
                         f"Cache invalidated for {query_type}({term_id}): cached version "
                         f"{cached_version} older than current {current_version}"
                     )
-                    self._clear_expired_cache_document(cache_doc_id)
+                    purge(cache_doc_id)
                 else:
                     logger.info(
                         f"Cache miss for {query_type}({term_id}): cached version "
@@ -364,7 +481,7 @@ class SolrResultCache:
                 if now > expires_at:
                     age_days = (now - cached_at).days
                     logger.info(f"Cache expired for {query_type}({term_id}) - age: {age_days} days")
-                    self._clear_expired_cache_document(cache_doc_id)
+                    purge(cache_doc_id)
                     return None
                     
                 # Log cache age for monitoring
@@ -373,7 +490,7 @@ class SolrResultCache:
                     
             except (KeyError, ValueError) as e:
                 logger.warning(f"Invalid cache metadata for {term_id}: {e}")
-                self._clear_expired_cache_document(cache_doc_id)
+                purge(cache_doc_id)
                 return None
             
             # Check if cached result parameters are compatible with requested parameters
@@ -426,7 +543,7 @@ class SolrResultCache:
             if isinstance(result, dict) and 'count' in result:
                 if result.get('count', -1) < 0:
                     logger.warning(f"Rejecting cached error result for {query_type}({term_id}): count={result.get('count')}")
-                    self._clear_expired_cache_document(cache_doc_id)
+                    purge(cache_doc_id)
                     return None
             
             logger.info(f"Cache hit for {query_type}({term_id})")
@@ -472,7 +589,7 @@ class SolrResultCache:
                 
             # Create cache document with prefixed ID including query type
             # This ensures different query types for the same term have separate cache entries
-            cache_doc_id = f"vfb_query_{query_type}_{term_id}"
+            cache_doc_id = cache_doc_id_for(query_type, term_id)
             
             # Serialise then gzip the envelope. The size cap is enforced here, on
             # the compressed payload that is actually stored.
@@ -575,7 +692,7 @@ class SolrResultCache:
             return False
         try:
             # Include query_type in cache document ID to match storage format
-            cache_doc_id = f"vfb_query_{query_type}_{term_id}"
+            cache_doc_id = cache_doc_id_for(query_type, term_id)
             response = requests.post(
                 f"{self.cache_url}/update",
                 data=f'<delete><id>{cache_doc_id}</id></delete>',
@@ -593,6 +710,40 @@ class SolrResultCache:
             logger.error(f"Error clearing cache entry: {e}")
             return False
     
+    def purge_namespace(self, namespace: Optional[str] = None) -> bool:
+        """Delete every cache document in a namespace.
+
+        Refuses to run against production: an empty namespace here would expand
+        to ``id:vfb_query_*`` and wipe the shared cache, which is exactly the
+        accident this whole mechanism exists to make impossible. CI calls this
+        when a branch is done with its scratch cache; otherwise the 48h TTL
+        collects it.
+        """
+        ns = cache_namespace() if namespace is None else namespace
+        if not ns:
+            logger.error("purge_namespace refused: no namespace set "
+                         "(refusing to delete the production cache)")
+            return False
+        if not self._solr_available():
+            return False
+        try:
+            response = requests.post(
+                f"{self.cache_url}/update",
+                data=f'<delete><query>id:{cache_doc_glob(ns)}</query></delete>',
+                headers={"Content-Type": "application/xml"},
+                params={"commit": "true"},
+                timeout=30
+            )
+            if response.status_code == 200:
+                logger.info("Purged cache namespace '%s'", ns)
+                return True
+            logger.error("Failed to purge cache namespace '%s': HTTP %s",
+                         ns, response.status_code)
+            return False
+        except Exception as e:
+            logger.error("Error purging cache namespace '%s': %s", ns, e)
+            return False
+
     def get_cache_age(self, query_type: str, term_id: str, **params) -> Optional[Dict[str, Any]]:
         """
         Get cache age information for a specific cached result
@@ -605,7 +756,7 @@ class SolrResultCache:
 
         try:
             # Include query_type in cache document ID to match storage format
-            cache_doc_id = f"vfb_query_{query_type}_{term_id}"
+            cache_doc_id = cache_doc_id_for(query_type, term_id)
             
             response = requests.get(f"{self.cache_url}/select", params={
                 "q": f"id:{cache_doc_id}",
@@ -667,7 +818,7 @@ class SolrResultCache:
             
             # Search for all cache documents
             response = requests.get(f"{self.cache_url}/select", params={
-                "q": "id:vfb_query_*",
+                "q": f"id:{cache_doc_glob()}",
                 "fl": "id,cache_data,expires_at",
                 "rows": "1000",  # Process in batches
                 "wt": "json"
@@ -741,7 +892,7 @@ class SolrResultCache:
         try:
             # Get all cache documents
             response = requests.get(f"{self.cache_url}/select", params={
-                "q": "id:vfb_query_*",
+                "q": f"id:{cache_doc_glob()}",
                 "fl": "id,query_type,cache_data,cached_at,expires_at",
                 "rows": "1000",  # Process in batches 
                 "wt": "json"
@@ -752,6 +903,7 @@ class SolrResultCache:
                 docs = data.get("response", {}).get("docs", [])
                 total_cache_docs = data.get("response", {}).get("numFound", 0)
                 
+                namespace = cache_namespace()
                 type_stats = {}
                 total_size = 0
                 expired_count = 0
@@ -823,6 +975,7 @@ class SolrResultCache:
                         expired_count += 1
                 
                 return {
+                    "cache_namespace": namespace or "production",
                     "total_cache_documents": total_cache_docs,
                     "cache_by_type": type_stats,
                     "expired_documents": expired_count,
@@ -836,6 +989,7 @@ class SolrResultCache:
             logger.error(f"Error getting cache stats: {e}")
             
         return {
+            "cache_namespace": cache_namespace() or "production",
             "total_cache_documents": 0,
             "cache_by_type": {},
             "expired_documents": 0,

--- a/src/vfbquery/vfb_connectivity.py
+++ b/src/vfbquery/vfb_connectivity.py
@@ -233,14 +233,24 @@ def _db_filter_predicate(var, exclude_dbs):
 def list_connectome_datasets():
     """List available connectome datasets from VFB.
 
-    :return: list of dicts with 'label' and 'symbol' keys
+    ``short_form`` is returned alongside ``symbol`` because both are legitimate
+    things to exclude with: :func:`_db_filter_predicate` compares against
+    ``Site.short_form`` *and* ``Site.symbol[0]``, so a caller who reads
+    ``flywire783`` off a term's cross-references and passes that to
+    ``exclude_dbs`` is not making a mistake. Returning the symbol alone left
+    them guessing which of the two spellings the filter wanted, and guessing
+    wrong used to be silent — see ``ha_api._resolve_exclude_dbs``.
+
+    :return: list of dicts with 'label', 'symbol' and 'short_form' keys
     """
     nc = _get_nc()
     results = nc.commit_list([
-        "MATCH (c:Connectome:Individual) RETURN c.label, c.symbol[0] ORDER BY c.label"
+        "MATCH (c:Connectome:Individual) "
+        "RETURN c.label, c.symbol[0], c.short_form ORDER BY c.label"
     ])
     dc = dict_cursor(results)
-    return [{"label": r["c.label"], "symbol": r["c.symbol[0]"]} for r in dc]
+    return [{"label": r["c.label"], "symbol": r["c.symbol[0]"],
+             "short_form": r["c.short_form"]} for r in dc]
 
 
 def _connectivity_cache_key(upstream_type, downstream_type, weight,

--- a/src/vfbquery/vfb_connectivity.py
+++ b/src/vfbquery/vfb_connectivity.py
@@ -56,9 +56,23 @@ DEFAULT_EXCLUDE_DBS = ["hb", "fafb"]
 MAX_SUBCLASS_IDS = 10000
 
 
+_NC = None
+
+
 def _get_nc():
-    """Get a Neo4jConnect instance for VFB."""
-    return Neo4jConnect()
+    """Get a Neo4jConnect instance for VFB, reusing one per process.
+
+    Constructing ``Neo4jConnect`` runs a connection test to work out whether
+    the server speaks the v4 or v3 transaction API. Returning a fresh instance
+    per call meant that test ran again on every single query — a whole extra
+    round-trip against a shared, and at times very slow, production server,
+    paid before any useful work started. The answer does not change during a
+    process's life, so it is worked out once.
+    """
+    global _NC
+    if _NC is None:
+        _NC = Neo4jConnect()
+    return _NC
 
 
 def _cypher_str(value):
@@ -110,7 +124,8 @@ def _resolve_neuron_type_label(nc, label, notes=None):
             "Check the ID is a valid neuron class (not an anatomy region)."
         )
 
-    # Exact label match
+    # Exact label match. Kept on its own because it is the only step that is an
+    # index seek, and it is what almost every caller hits.
     results = nc.commit_list([
         f"MATCH (n:Class:Neuron) WHERE n.label = {quoted} "
         f"RETURN n.short_form LIMIT 1"
@@ -118,6 +133,16 @@ def _resolve_neuron_type_label(nc, label, notes=None):
     dc = dict_cursor(results)
     if dc:
         return dc[0]["n.short_form"]
+
+    # The tiers below stay as separate statements on purpose. Merging them into
+    # one `OR` was tried, on the reasoning that three sequential round-trips
+    # against an intermittently slow server is three chances to block; measured
+    # against production it was far worse. The single-predicate containment scan
+    # returns in well under a second, while the same scan with the equality and
+    # synonym disjuncts bolted on did not return inside forty seconds on any of
+    # six attempts — the disjunction costs the planner the filter it can push
+    # down. Split, each tier is also short-circuiting: a caller passing a real
+    # label never reaches the scan at all.
 
     # Case-insensitive label fallback
     results = nc.commit_list([


### PR DESCRIPTION
Three classes of defect, all the same shape: the service answered **200 to a question the caller did not ask**, and nothing in the response distinguished it from the one they meant. Everything here is a patch-level change — no cache namespace bump, so this releases as **v1.22.36**.

## 1. Parameters that were read and discarded now report themselves

Every affected endpoint gained a declared parameter set. Anything outside it is named back with the closest real name — `filter_type` → `filter_types`, `min_weight` → `weight`, `short_form` → `id`. A boolean whose value is not among the accepted spellings (`true/1/yes/on`, `false/0/no/off`) is reported rather than read as false: `include_graph=y` was previously indistinguishable from not passing the flag.

Beyond those two generic checks, each handler says when it ignored something specific:

- `include_graph` on one of the 36 query types that cannot draw a graph — and lists the four that can, instead of returning a graphless result that reads as "this query has no graph".
- `offset`/`limit` on a query type that does not page; a non-integer or negative page parameter.
- an `id` sent to `query_type=AllDatasets`, which takes none — the answer looked like a filtered dataset list rather than the whole thing.
- `/combine`'s `offset`, `order_by` and `force_refresh`: reserved names that are not implemented, previously skipped in silence.

`/search`'s `rows` is still clamped rather than rejected, but says so — `rows` sizes the candidate pool the comparator ranks, so silently shrinking it changes the **order** of the top of the list, not just its length. `limit=0` used to return `rows: []` beside a `count` of 1537, a result set that reports matches and shows none; that one is now a **400**.

None of this changes a status code except `limit=0`. These are 200s that were already 200s. What changed is that they no longer look identical to the response the caller intended.

## 2. `exclude_dbs` is validated instead of silently matching nothing

The values reach Cypher as an exact string comparison against `Site.short_form` **and** `Site.symbol[0]`, so `exclude_dbs=hemibrain` excluded nothing and returned the same double-counted answer as sending no filter at all — wearing a perfectly ordinary 200 whose only symptom was inflated counts.

Values now resolve against the live dataset list through the same nickname algorithm `/xref`'s `db` already uses, so a symbol (`mc`), a short_form (`male_cns_v0_9`), a label word (`male-cns`) or a whole label all name one dataset. An unrecognised one is a 400 with suggestions and a pointer to `/list_connectome_datasets`.

Two properties were preserved deliberately, and are worth keeping if this is ever rewritten:

- The canonical form is the **symbol**, which is what `DEFAULT_EXCLUDE_DBS` already holds — so the default resolves to itself and **no cached answer is orphaned**. Only spellings that were previously broken get new keys.
- Caller order is preserved rather than sorted, for the same reason: `[hb, fafb]` must not become `[fafb, hb]`.

`/query_connectivity` now echoes `excluded_dbs` so a caller can see what the answer covers without re-deriving it, and `list_connectome_datasets` returns `short_form` alongside `symbol`, because both are legitimate things to exclude with and returning one left callers guessing which.

## 3. A slow computation is no longer killed by the client that gave up

`query_connectivity` on a large-against-large type pair — `Tm1 → T3`, 4,915 individuals against 5,430 — was measured at **over 40 minutes without returning** (a 2,400s probe came back with zero bytes).

The worker ran inline in the request coroutine. So a client hanging up, a proxy giving up, or a handler timing out **cancelled the computation mid-flight**, and because `CancelledError` is a `BaseException` it died quietly with nothing written to the cache. The next caller started the same forty minutes from scratch, and so did the one after that: a query slow enough to lose one client could never finish for anybody. Worse, every request coalesced onto the key was woken by `_abandon` with "Request aborted, please retry" and pointed back at exactly the query that had just proved nobody waits that long.

Two small helpers fix it:

- `_spawn_compute` runs the worker as a task that owns the coalescing future and the cache write, so it **outlives its caller**.
- `_shielded` gives the handler a bounded wait that does not cancel what it is waiting on.

Past `VFBQUERY_COMPUTE_BUDGET` seconds (default 180) the handler answers **`503` with `status: "computing"`** and `Retry-After: 30`; the work continues and the retry finds the finished result. A client polling every 30s coalesces onto the same future, so there is no duplicate work.

This is strictly less resource use than before, not more: `run_in_executor` futures **cannot be cancelled once the thread has started**, so the old code already occupied a pool thread for the full duration and merely threw the result away.

Applied to `_dispatch_to_pool`, `/get_term_info` and `/run_query`. `/search` deliberately keeps its own inline block — its work is a bounded Solr call behind a separate semaphore with a 10s queue wait, not a multi-minute executor walk.

`/get_hierarchy_html` also stopped parsing a non-200 dispatch for `html` and answering "No hierarchy data found", which turned every 503 and 500 into a 404 about missing data and swallowed the `Retry-After` that told the browser the answer was still coming.

## Also in here

`/facets` added to `ALLOWED_PATHS`: `/search`'s four type parameters 400 with "did you mean" suggestions and point the caller at `/facets` for the full list, so an allowlist that 404s the endpoint its own error message names is a dead end by construction.

`_search_payload`'s cache key regains its ninth slot (`str(unique)`). Without it, a `search:` operand inside `/combine` and a direct `/search` for the same text computed and stored the same answer under two different keys and never shared one.

## Tests

`src/test/test_ha_api_dispatch.py` — 25 new unit tests (32 pass with `test_ha_api_validation.py`, 1.1s), covering the warning helpers, `exclude_dbs` resolution including the default's round-trip, `_shielded`'s non-cancelling timeout and `_spawn_compute`'s cache/coalesce/failure paths. The headline one is `test_spawn_compute_survives_a_handler_that_gives_up`: the handler abandons its wait, and the finished computation still lands in the cache.

Deliberately free of Neo4j and Solr. This is plumbing between an HTTP request and a worker, and a live query is exactly what hides it — the compute-budget behaviour in particular can only be tested with a worker whose duration is known in advance. No `pytest-asyncio` dependency either: the coroutine tests use a four-line `asyncio.run` wrapper rather than asking CI to install something on every run.

## Docs

`docs/http-api.md` and `CACHING.md`. The stale "not yet on the public deploy" note for `/search`, `/xref` and `/combine` is gone (they shipped in 1.22.35), the `Tm1 → T3` timing claim of "30 to 60s" is corrected to what was actually measured, and `VFBQUERY_COMPUTE_BUDGET` is documented in `CACHING.md` rather than as a timeout, because that is what it is: the first slow request is what warms the entry for everyone behind it.

`README.md` untouched — it is GA-generated.

## Three things deliberately **not** fixed here, for review

**`ALLOWED_PATHS` is inert on the public deploy.** `security_middleware` checks `request.path not in ALLOWED_PATHS and not _is_trusted_remote(request.remote)`, and behind the k8s ingress `request.remote` *is* the ingress — inside `TRUSTED_NETWORKS`. Verified live from outside the cluster: `/facets` → 200 and `/get_hierarchy_html` → 200, while `/nonexistent` → 404 from the router rather than the middleware. Making it effective means honouring `X-Forwarded-For`, which changes who can reach what — a breaking change, not a patch. It is now documented as a warning in `docs/http-api.md` so nobody treats the allowlist as access control in the meantime. **Worth a decision from you.**

**`/find_stocks`' `collection` substring filter.** An unmatched collection name returns an empty array with no explanation. The endpoint returns a bare JSON array, so `_with_warnings` is a no-op on it and adding an `available_collections` key would change the response *shape* — a breaking change for anything indexing `[0]`. Left for a version that can afford it.

**The `query_connectivity` Cypher itself.** The mitigation above makes the 40 minutes survivable; it does not make them shorter. I could not measure the plan from this environment — the sandbox's egress blocks POST to `pdb.virtualflybrain.org/db/neo4j/tx/commit`, so no `EXPLAIN`. From reading `_build_connectivity_cypher`, the strongest candidate is in the `group_by_class` branch: the `total_upstream_count` denominator re-expands `(c1)<-[:INSTANCEOF]-(all_n1)` **once per `(c1, c2)` pair** rather than once per `c1`, which on a broad optic-lobe pair is thousands of re-walks of the same instance set. A `collect`/`UNWIND` restructure would make it once per `c1` with identical semantics. Second candidate: the non-grouped `RETURN`'s two `OPTIONAL MATCH … database_cross_reference` expansions land *before* an implicit aggregation over ~13 grouping keys. Neither is something I want to ship unverified into a release you are about to deploy — **filing as a follow-up rather than guessing.**
