### PR TITLE
Stop a stalled Neo4j from hanging the Performance Test job

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,16 @@ markers = [
     "integration: integration tests that exercise the live VFB upstream (Neo4j, SOLR, owlery). Skip via -m 'not integration'.",
 ]
 
+# Ceiling on any single test. The upstream Neo4j intermittently stops answering
+# for minutes at a time; with no per-test bound one test caught in that absorbs
+# the whole job, and the run is killed by the runner's own limit with nothing to
+# say which test was stuck. This turns that into one named failure. It is a
+# backstop, not a performance target — a healthy connectivity query returns in a
+# couple of seconds, so anything near this is already a fault. Needs
+# pytest-timeout; without it pytest warns about the unknown option and carries
+# on, so it degrades to the old behaviour rather than breaking the run.
+timeout = 300
+
 # Silence the marshmallow deprecation warnings that bubble up from inside
 # the library itself (marshmallow/fields.py:582,776,986,1218). Our own
 # code calls to `missing=`/`fields.Field()` have been migrated to

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ get_version
 aiohttp
 psycopg[binary]>=3.0
 pytest
+pytest-timeout

--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -16,17 +16,31 @@ before the client's module-level constants are evaluated.
 """
 import os
 
-#: Fail-fast Neo4j settings for tests. Deliberately much tighter than the
-#: library defaults (120s read, 3 retries): a healthy query against production
-#: returns in a couple of seconds, so 45s is already far beyond normal, and one
-#: retry is enough to ride out a dropped connection without turning a dead
-#: upstream into minutes of waiting per statement.
+#: Fail-fast Neo4j settings for tests. Tighter than the library defaults
+#: (120s read, 3 retries), because one retry is enough to ride out a dropped
+#: connection without turning a dead upstream into minutes of waiting per
+#: statement.
+#:
+#: The read timeout is 180s rather than the 45s first used here. 45s was
+#: chosen on the assumption that a healthy query returns in a couple of
+#: seconds, which is true of most of them and not true of the class-level
+#: connectivity queries: ``get_downstream_class_connectivity('FBbt_00001482')``
+#: is measured at 106s against a healthy production server, returning 9,095
+#: rows. Those tests pass ``force_refresh=True`` and run with the cache
+#: disabled, so every one of them pays that in full — under 45s they did not
+#: time out so much as report an empty table, and nine of them failed on
+#: assertions about rows that had simply never arrived. The tight value was
+#: also invisible until recently: the client used to freeze its constants at
+#: import, so this file's settings never reached the queries at all.
+#:
+#: A stalled server is still bounded — 180s x 2 attempts, and the client now
+#: sends ``max-execution-time`` so the server abandons the work as well.
 #:
 #: ``setdefault``, not assignment — a workflow or a developer that has set one
 #: of these deliberately keeps it.
 TEST_NEO4J_DEFAULTS = {
     "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
-    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
+    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "180",
     "VFBQUERY_NEO4J_MAX_RETRIES": "1",
     "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
     "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",

--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -1,0 +1,42 @@
+"""Test package for VFBquery.
+
+This file exists to hold one piece of setup: the Neo4j client's fail-fast
+settings for tests. It lives here rather than in ``conftest.py`` because
+``conftest.py`` is a pytest mechanism, and not every job runs pytest — the
+conda workflow runs the suite through ``unittest``, which imports
+``src.test.<module>`` and never looks at a conftest. When these defaults were
+in conftest only, that job kept the library's REPL-tuned patience and a single
+statement against a stalled upstream cost 120s x 4 attempts; one test measured
+582s against its own 120s threshold for that reason alone. Importing the
+package is the one thing both runners are guaranteed to do.
+
+The settings are read at import time by ``vfbquery.neo4j_client``, and this
+module is imported before any test module in the package, so they are in place
+before the client's module-level constants are evaluated.
+"""
+import os
+
+#: Fail-fast Neo4j settings for tests. Deliberately much tighter than the
+#: library defaults (120s read, 3 retries): a healthy query against production
+#: returns in a couple of seconds, so 45s is already far beyond normal, and one
+#: retry is enough to ride out a dropped connection without turning a dead
+#: upstream into minutes of waiting per statement.
+#:
+#: ``setdefault``, not assignment — a workflow or a developer that has set one
+#: of these deliberately keeps it.
+TEST_NEO4J_DEFAULTS = {
+    "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
+    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
+    "VFBQUERY_NEO4J_MAX_RETRIES": "1",
+    "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
+    "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",
+}
+
+
+def apply_test_neo4j_defaults():
+    """Set the fail-fast Neo4j environment defaults, leaving any already set."""
+    for name, value in TEST_NEO4J_DEFAULTS.items():
+        os.environ.setdefault(name, value)
+
+
+apply_test_neo4j_defaults()

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -1,0 +1,32 @@
+"""Shared setup for the integration test suite.
+
+The one job here is to make the Neo4j client fail fast under test. The library's
+defaults are tuned for a person at a REPL, who would rather wait than be told to
+try again; a CI job wants the opposite. The upstream at
+pdb.virtualflybrain.org intermittently stops answering for minutes at a time,
+and with the library defaults a single statement caught in that can spend
+several minutes retrying before it gives up — multiplied across the connectivity
+suite, that is the difference between a job that fails in a readable way and one
+the runner kills at its own ceiling with nothing to show for it.
+
+These are read at import time by ``vfbquery.neo4j_client``, so they are set
+here — conftest is imported before any test module — and only when not already
+set, so a workflow or a developer can still override them from the environment.
+"""
+import os
+
+#: Fail-fast Neo4j settings for tests. Deliberately much tighter than the
+#: library defaults (120s read, 3 retries): a healthy connectivity query against
+#: production returns in a couple of seconds, so 45s is already far beyond
+#: normal, and one retry is enough to ride out a dropped connection without
+#: turning a dead upstream into minutes of waiting per statement.
+_TEST_NEO4J_DEFAULTS = {
+    "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
+    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
+    "VFBQUERY_NEO4J_MAX_RETRIES": "1",
+    "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
+    "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",
+}
+
+for _name, _value in _TEST_NEO4J_DEFAULTS.items():
+    os.environ.setdefault(_name, _value)

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -1,32 +1,28 @@
-"""Shared setup for the integration test suite.
+"""Shared pytest setup for the test suite.
 
-The one job here is to make the Neo4j client fail fast under test. The library's
-defaults are tuned for a person at a REPL, who would rather wait than be told to
-try again; a CI job wants the opposite. The upstream at
-pdb.virtualflybrain.org intermittently stops answering for minutes at a time,
-and with the library defaults a single statement caught in that can spend
-several minutes retrying before it gives up — multiplied across the connectivity
-suite, that is the difference between a job that fails in a readable way and one
-the runner kills at its own ceiling with nothing to show for it.
+The Neo4j fail-fast defaults these tests need live in ``src/test/__init__.py``
+rather than here, because not every job runs pytest — the conda workflow drives
+the suite through ``unittest``, which imports ``src.test.<module>`` and never
+reads a conftest. Importing the package is the one thing both runners do.
 
-These are read at import time by ``vfbquery.neo4j_client``, so they are set
-here — conftest is imported before any test module — and only when not already
-set, so a workflow or a developer can still override them from the environment.
+This file re-applies them anyway, so the settings do not depend on pytest having
+imported the parent package first. It is a no-op when it has, because the
+underlying call uses ``os.environ.setdefault``.
 """
-import os
+try:
+    from . import apply_test_neo4j_defaults
+except ImportError:  # collected without the package, e.g. rootdir-relative
+    import os
 
-#: Fail-fast Neo4j settings for tests. Deliberately much tighter than the
-#: library defaults (120s read, 3 retries): a healthy connectivity query against
-#: production returns in a couple of seconds, so 45s is already far beyond
-#: normal, and one retry is enough to ride out a dropped connection without
-#: turning a dead upstream into minutes of waiting per statement.
-_TEST_NEO4J_DEFAULTS = {
-    "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
-    "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
-    "VFBQUERY_NEO4J_MAX_RETRIES": "1",
-    "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
-    "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",
-}
+    def apply_test_neo4j_defaults():
+        for name, value in {
+            "VFBQUERY_NEO4J_CONNECT_TIMEOUT_S": "10",
+            "VFBQUERY_NEO4J_READ_TIMEOUT_S": "45",
+            "VFBQUERY_NEO4J_MAX_RETRIES": "1",
+            "VFBQUERY_NEO4J_RETRY_BACKOFF_S": "2",
+            "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S": "10",
+        }.items():
+            os.environ.setdefault(name, value)
 
-for _name, _value in _TEST_NEO4J_DEFAULTS.items():
-    os.environ.setdefault(_name, _value)
+
+apply_test_neo4j_defaults()

--- a/src/test/test_query_performance.py
+++ b/src/test/test_query_performance.py
@@ -397,16 +397,25 @@ class QueryPerformanceTest(unittest.TestCase):
         print("="*80)
 
         # Both-end + group_by_class is the fastest variant per LLM guidance.
-        # giant fiber neuron → peripherally synapsing interneuron is a
-        # known-good pair with non-zero results.
+        #
+        # The downstream side is not ``peripherally synapsing interneuron``,
+        # which was used here until it was measured. All 17 of its connections
+        # to the giant fiber live in ``hb`` or ``fafb``, both of which
+        # ``DEFAULT_EXCLUDE_DBS`` removes, so that pair answered 0 — and since
+        # this test only timed the call, it never noticed it was timing an
+        # empty result. ``giant fiber coupled neuron 2`` gives 42 connections
+        # under the same defaults.
         result, duration, success = self._time_query(
             "QueryConnectivity",
             query_connectivity,
             upstream_type="giant fiber neuron",
-            downstream_type="peripherally synapsing interneuron",
+            downstream_type="giant fiber coupled neuron 2",
             group_by_class=True,
         )
         print(f"QueryConnectivity: {duration:.4f}s {'✅' if success else '❌'}")
+        # A performance test that passes on an empty table measures nothing.
+        self.assertTrue(success and result and result.get("count", 0) > 0,
+                        "QueryConnectivity returned no connections")
         # Live cross-dataset query — allow up to 5 min per the MCP timeout.
         self.assertLess(duration, 300.0, "QueryConnectivity exceeded threshold")
 
@@ -462,10 +471,20 @@ class QueryPerformanceTest(unittest.TestCase):
         # anatomy classes). Use VFBexp_FBtp0001321 (P{GAL4-per.BS}),
         # known to overlap ~50 anatomy classes in pdb.
         EP_EXAMPLE = 'VFBexp_FBtp0001321'
-        try:
-            get_expression_overlaps_here(EP_EXAMPLE, return_dataframe=False, limit=-1)
-        except Exception:
-            pass  # Ignore warm-up failures
+
+        # Warm the cache — but only where a write can actually land. Under
+        # VFBQUERY_CACHE_READONLY (how every PR check runs) this limit=-1 call
+        # cannot be stored, so it is the uncapped AnatomyExpressedIn traversal
+        # run for nothing: minutes of server time per job, and the shape that
+        # took pdb down. The timed call below asks for ten rows and now gets
+        # exactly that.
+        from vfbquery.solr_result_cache import solr_caching_readonly
+
+        if not solr_caching_readonly():
+            try:
+                get_expression_overlaps_here(EP_EXAMPLE, return_dataframe=False, limit=-1)
+            except Exception:
+                pass  # Ignore warm-up failures
 
         result, duration, success = self._time_query(
             "AnatomyExpressedIn (P{GAL4-per.BS} expression pattern)",

--- a/src/test/test_vfb_connectivity.py
+++ b/src/test/test_vfb_connectivity.py
@@ -1,10 +1,52 @@
-"""Tests for vfb_connectivity module — connectome datasets and neuron connectivity."""
+"""Tests for vfb_connectivity module — connectome datasets and neuron connectivity.
+
+Fixture choice matters here. Every test in this file is an integration test that
+runs against the shared production Neo4j, and CI runs them with the SOLR result
+cache disabled, so each call is paid in full. Two rules keep that affordable:
+
+* Prefer small classes. ``giant fiber neuron`` (8 individuals) and
+  ``peripherally synapsing interneuron`` (6) are used wherever the assertion
+  does not depend on the class being large.
+* Where a large class is the point — ``Kenyon cell`` has no individuals of its
+  own and ~16,000 under its subclasses, which is exactly what the subclass
+  expansion tests exist to check — ask for it with ``group_by_class=True``.
+  That bounds the reply at one row per class pair instead of one per individual
+  pair, so the traversal under test is unchanged while the table that comes
+  back over the wire stays in the tens of rows.
+
+The expensive results are also module-scoped fixtures rather than repeated
+calls, so the three tests that need the same query cost one query between them.
+"""
 import pytest
 
 from vfbquery.vfb_connectivity import list_connectome_datasets, query_connectivity
 
+#: A small, stable pair: 8 and 6 connectivity individuals respectively, one
+#: class each, no subclasses. Cheap enough to query several times.
 KNOWN_UPSTREAM = "giant fiber neuron"
 KNOWN_DOWNSTREAM = "peripherally synapsing interneuron"
+
+#: The subclass-expansion pair. DA1 lPN has 68 individuals; Kenyon cell has none
+#: of its own and ~16,000 across 38 subclasses. Only ever queried grouped.
+EXPANSION_UPSTREAM = "DA1 lPN"
+EXPANSION_UPSTREAM_ID = "FBbt_00067363"
+EXPANSION_DOWNSTREAM = "Kenyon cell"
+EXPANSION_DOWNSTREAM_ID = "FBbt_00003686"
+
+
+@pytest.fixture(scope="module")
+def expansion_result():
+    """DA1 lPN -> Kenyon cell, grouped, run once for the whole module."""
+    return query_connectivity(
+        upstream_type=EXPANSION_UPSTREAM,
+        downstream_type=EXPANSION_DOWNSTREAM,
+        group_by_class=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def datasets():
+    return list_connectome_datasets()
 
 
 # ---------------------------------------------------------------------------
@@ -14,26 +56,22 @@ KNOWN_DOWNSTREAM = "peripherally synapsing interneuron"
 
 class TestListConnectomeDatasets:
     @pytest.mark.integration
-    def test_returns_datasets(self):
-        datasets = list_connectome_datasets()
+    def test_returns_datasets(self, datasets):
         assert len(datasets) > 0
 
     @pytest.mark.integration
-    def test_datasets_have_label_and_symbol(self):
-        datasets = list_connectome_datasets()
+    def test_datasets_have_label_and_symbol(self, datasets):
         for d in datasets:
             assert "label" in d
             assert "symbol" in d
 
     @pytest.mark.integration
-    def test_hemibrain_present(self):
-        datasets = list_connectome_datasets()
+    def test_hemibrain_present(self, datasets):
         symbols = [d["symbol"] for d in datasets]
         assert "hb" in symbols
 
     @pytest.mark.integration
-    def test_every_dataset_has_symbol(self):
-        datasets = list_connectome_datasets()
+    def test_every_dataset_has_symbol(self, datasets):
         for d in datasets:
             assert d["symbol"], f"Dataset {d['label']} has empty symbol"
 
@@ -55,16 +93,25 @@ class TestQueryConnectivityKnown:
 
     @pytest.mark.integration
     def test_both_types_subset_of_either_alone(self):
-        result_both = query_connectivity(
+        # Grouped on all three sides: a one-sided query returns every partner of
+        # the named type, which is the one shape in this file that can run to
+        # thousands of rows. Grouping bounds it at class pairs, and the
+        # containment being asserted holds either way.
+        both = query_connectivity(
             upstream_type=KNOWN_UPSTREAM,
             downstream_type=KNOWN_DOWNSTREAM,
+            group_by_class=True,
         )
-        result_up = query_connectivity(upstream_type=KNOWN_UPSTREAM)
-        result_down = query_connectivity(downstream_type=KNOWN_DOWNSTREAM)
+        up_only = query_connectivity(
+            upstream_type=KNOWN_UPSTREAM, group_by_class=True,
+        )
+        down_only = query_connectivity(
+            downstream_type=KNOWN_DOWNSTREAM, group_by_class=True,
+        )
 
-        assert result_both["count"] > 0
-        assert result_both["count"] <= result_up["count"]
-        assert result_both["count"] <= result_down["count"]
+        assert both["count"] > 0
+        assert both["count"] <= up_only["count"]
+        assert both["count"] <= down_only["count"]
 
 
 class TestQueryConnectivityGroupByClass:
@@ -99,8 +146,7 @@ class TestQueryConnectivityWeightFiltering:
 
 class TestQueryConnectivityExcludeDbs:
     @pytest.mark.integration
-    def test_exclude_all_returns_no_results(self):
-        datasets = list_connectome_datasets()
+    def test_exclude_all_returns_no_results(self, datasets):
         all_symbols = [d["symbol"] for d in datasets]
         result = query_connectivity(
             upstream_type=KNOWN_UPSTREAM,
@@ -115,40 +161,38 @@ class TestQueryConnectivitySubclassExpansion:
     with an empty table that reads as 'not connected'."""
 
     @pytest.mark.integration
-    def test_parent_class_with_no_direct_instances_returns_results(self):
+    def test_parent_class_with_no_direct_instances_returns_results(self, expansion_result):
         # Kenyon cell has zero directly-typed individuals; all ~16,000 sit under
         # its subclasses. Matching the named class alone returns nothing.
-        result = query_connectivity(
-            upstream_type="DA1 lPN", downstream_type="Kenyon cell",
-        )
-        assert result["count"] > 0
-        assert result["resolved"]["downstream"]["classes_searched"] > 1
-        assert result["resolved"]["downstream"]["instances"] > 1000
+        assert expansion_result["count"] > 0
+        assert expansion_result["resolved"]["downstream"]["classes_searched"] > 1
+        assert expansion_result["resolved"]["downstream"]["instances"] > 1000
 
     @pytest.mark.integration
-    def test_resolved_reports_how_a_label_was_read(self):
-        result = query_connectivity(
-            upstream_type="DA1 lPN", downstream_type="Kenyon cell",
-        )
-        up = result["resolved"]["upstream"]
-        assert up["query"] == "DA1 lPN"
-        assert up["id"] == "FBbt_00067363"
+    def test_resolved_reports_how_a_label_was_read(self, expansion_result):
+        up = expansion_result["resolved"]["upstream"]
+        assert up["query"] == EXPANSION_UPSTREAM
+        assert up["id"] == EXPANSION_UPSTREAM_ID
         # A non-exact resolution has to be stated, not silently applied.
-        assert any("DA1 lPN" in w for w in result["warnings"])
+        assert any(EXPANSION_UPSTREAM in w for w in expansion_result["warnings"])
 
     @pytest.mark.integration
     def test_anchor_side_does_not_change_the_answer(self):
         # The query is driven from whichever side has fewer individuals; that is
-        # a performance choice and must not be an answer choice.
+        # a performance choice and must not be an answer choice. Run on the
+        # small pair: forcing the anchor onto Kenyon cell's ~16,000 individuals
+        # tested nothing extra and cost the most of anything in this file.
         from vfbquery.vfb_connectivity import (
             _get_nc, _subclass_closure, _build_connectivity_cypher,
-            DEFAULT_EXCLUDE_DBS,
+            _resolve_neuron_type_label, DEFAULT_EXCLUDE_DBS,
         )
         from vfbquery.neo4j_client import dict_cursor
 
         nc = _get_nc()
-        _, up_ids, _ = _subclass_closure(nc, "FBbt_00067363")   # DA1 lPN
-        _, down_ids, _ = _subclass_closure(nc, "FBbt_00003686")  # Kenyon cell
+        up_id = _resolve_neuron_type_label(nc, KNOWN_UPSTREAM)
+        down_id = _resolve_neuron_type_label(nc, KNOWN_DOWNSTREAM)
+        _, up_ids, _ = _subclass_closure(nc, up_id)
+        _, down_ids, _ = _subclass_closure(nc, down_id)
         counts = []
         for anchor in ("upstream", "downstream"):
             cypher = _build_connectivity_cypher(
@@ -159,8 +203,8 @@ class TestQueryConnectivitySubclassExpansion:
 
     @pytest.mark.integration
     def test_ambiguous_label_lists_candidates(self):
-        # "neuron " (with the trailing space) is contained in a great many
-        # labels and matches none exactly, so it must not be guessed at.
+        # Matches several labels by containment and none exactly, so it must not
+        # be guessed at.
         result = query_connectivity(upstream_type="lobe projection neuron D")
         assert result["count"] == 0
         assert any("ambiguous" in w for w in result["warnings"])
@@ -168,18 +212,20 @@ class TestQueryConnectivitySubclassExpansion:
 
 class TestQueryConnectivityExcludeDbsDefault:
     @pytest.mark.integration
-    def test_default_excludes_are_a_strict_subset_of_everything(self):
+    def test_default_excludes_are_a_strict_subset_of_everything(self, expansion_result):
+        # Grouped, and reusing the module fixture for the default half, so this
+        # costs one extra query rather than two full ungrouped ones over every
+        # dataset — which is what made it the most expensive test here.
         from vfbquery.vfb_connectivity import DEFAULT_EXCLUDE_DBS
 
-        default = query_connectivity(
-            upstream_type="DA1 lPN", downstream_type="Kenyon cell",
-        )
         everything = query_connectivity(
-            upstream_type="DA1 lPN", downstream_type="Kenyon cell",
+            upstream_type=EXPANSION_UPSTREAM,
+            downstream_type=EXPANSION_DOWNSTREAM,
             exclude_dbs=[],
+            group_by_class=True,
         )
         assert DEFAULT_EXCLUDE_DBS == ["hb", "fafb"]
-        assert 0 < default["count"] < everything["count"]
+        assert 0 < expansion_result["count"] < everything["count"]
 
     @pytest.mark.integration
     def test_default_matches_passing_it_explicitly(self):

--- a/src/test/test_vfb_connectivity.py
+++ b/src/test/test_vfb_connectivity.py
@@ -5,8 +5,8 @@ runs against the shared production Neo4j, and CI runs them with the SOLR result
 cache disabled, so each call is paid in full. Two rules keep that affordable:
 
 * Prefer small classes. ``giant fiber neuron`` (8 individuals) and
-  ``peripherally synapsing interneuron`` (6) are used wherever the assertion
-  does not depend on the class being large.
+  ``giant fiber coupled neuron 2`` (30) are used wherever the assertion does
+  not depend on the class being large.
 * Where a large class is the point — ``Kenyon cell`` has no individuals of its
   own and ~16,000 under its subclasses, which is exactly what the subclass
   expansion tests exist to check — ask for it with ``group_by_class=True``.
@@ -21,10 +21,20 @@ import pytest
 
 from vfbquery.vfb_connectivity import list_connectome_datasets, query_connectivity
 
-#: A small, stable pair: 8 and 6 connectivity individuals respectively, one
-#: class each, no subclasses. Cheap enough to query several times.
+#: A small, stable pair: 8 and 30 connectivity individuals respectively, one
+#: class each, no subclasses. Cheap enough to query several times — the two
+#: sides give 42 connections under the default excludes in well under two
+#: seconds.
+#:
+#: The downstream side is deliberately not ``peripherally synapsing
+#: interneuron``, which reads like the obvious partner for the giant fiber and
+#: was used here until it was actually measured. Every one of its 17
+#: connections to ``giant fiber neuron`` lives in ``hb`` or ``fafb``, so
+#: ``DEFAULT_EXCLUDE_DBS`` removes all of them and the pair answers 0 —
+#: silently, since an empty table is a valid answer. A fixture for this file
+#: has to be checked against the *default* excludes, not merely shown to exist.
 KNOWN_UPSTREAM = "giant fiber neuron"
-KNOWN_DOWNSTREAM = "peripherally synapsing interneuron"
+KNOWN_DOWNSTREAM = "giant fiber coupled neuron 2"
 
 #: The subclass-expansion pair. DA1 lPN has 68 individuals; Kenyon cell has none
 #: of its own and ~16,000 across 38 subclasses. Only ever queried grouped.

--- a/src/vfbquery/neo4j_client.py
+++ b/src/vfbquery/neo4j_client.py
@@ -65,11 +65,72 @@ RETRY_BACKOFF_S = 2.0
 #: path's patience — see :meth:`Neo4jConnect._probe`.
 CONNECTION_TEST_TIMEOUT_S = 15.0
 
+#: How long a single statement may run on the server, in seconds, regardless of
+#: how briefly this client intends to wait for it. See
+#: :func:`_execution_budget_ms`.
+SERVER_MAX_EXECUTION_S = 300.0
+
+#: A caller that has explicitly asked to wait longer than the ceiling gets this
+#: multiple of its own read timeout instead, so raising
+#: ``VFBQUERY_NEO4J_READ_TIMEOUT_S`` for a genuinely long analytical query still
+#: works.
+SERVER_BUDGET_FACTOR = 2.0
+
+#: Neo4j status codes that mean "the server stopped this itself". Retryable:
+#: the server says as much in the message it sends back.
+TERMINATED_CODES = (
+    "Neo.DatabaseError.Statement.ExecutionFailed",
+    "Neo.ClientError.Transaction.TransactionTimedOut",
+    "Neo.ClientError.Transaction.Terminated",
+)
+
 #: Transaction endpoints, newest first. VFB production speaks the first.
 V4_COMMIT_PATH = "/db/neo4j/tx/commit"
 V4_HEADERS = {'Content-type': 'application/json'}
 V3_COMMIT_PATH = "/db/data/transaction/commit"
 V3_HEADERS = {}
+
+
+def _is_terminated(response):
+    """True if this response is the server reporting it stopped the work itself."""
+    try:
+        errors = response.json().get('errors') or []
+    except ValueError:
+        return False
+    return any(e.get('code') in TERMINATED_CODES for e in errors)
+
+
+def _execution_budget_ms(read_timeout_s, factor=None, ceiling_s=None):
+    """Milliseconds to allow the *server* for a statement, as a header value.
+
+    A ``requests`` timeout only ends this side of the conversation. The
+    transaction it started keeps running on the database: measured here, a
+    query that took pdb.virtualflybrain.org down carried on after the client
+    had given up, and after the client process had been killed outright. So
+    every retry stacked another copy of the same expensive traversal onto a
+    server that was already struggling, which is how one bad query became an
+    hour-long outage.
+
+    Neo4j's HTTP API accepts ``max-execution-time`` (milliseconds) and
+    honours it: ``CALL apoc.util.sleep(6000)`` sent with
+    ``max-execution-time: 1000`` was killed after 2.16s with
+    ``Neo.DatabaseError.Statement.ExecutionFailed``. The documented
+    ``Neo4j-Transaction-Timeout`` header is ignored by this server — the same
+    sleep ran its full 6.18s — so it is not used.
+
+    The budget is a flat ceiling rather than something derived from the read
+    timeout. Deriving it was tried: at ``read_timeout + 5s`` and again at
+    ``read_timeout * 2``, legitimate connectivity queries that had always
+    passed started coming back as hard ``ExecutionFailed`` errors — 22 of them
+    in one run — because the client's patience is tuned for a healthy server
+    and these queries are simply slow. The ceiling exists to stop a runaway,
+    not to enforce a latency target, so it sits far above any query that
+    finishes. A caller who has explicitly asked to wait longer than the
+    ceiling gets ``factor`` times its own read timeout instead.
+    """
+    factor = SERVER_BUDGET_FACTOR if factor is None else factor
+    ceiling = SERVER_MAX_EXECUTION_S if ceiling_s is None else ceiling_s
+    return max(1000, int(max(read_timeout_s * factor, ceiling) * 1000))
 
 
 def dict_cursor(results):
@@ -123,6 +184,12 @@ class Neo4jConnect:
         self.connection_test_timeout = _env_float(
             "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S", CONNECTION_TEST_TIMEOUT_S
         )
+        self.server_budget_factor = _env_float(
+            "VFBQUERY_NEO4J_SERVER_BUDGET_FACTOR", SERVER_BUDGET_FACTOR
+        )
+        self.server_max_execution = _env_float(
+            "VFBQUERY_NEO4J_SERVER_MAX_EXECUTION_S", SERVER_MAX_EXECUTION_S
+        )
         self.commit = V4_COMMIT_PATH
         self.headers = dict(V4_HEADERS)
 
@@ -168,13 +235,25 @@ class Neo4jConnect:
 
         max_retries = getattr(self, "max_retries", MAX_RETRIES)
         delay = getattr(self, "retry_backoff", RETRY_BACKOFF_S)
+
+        # Bound the work on the server too, not just the wait on this side —
+        # see _execution_budget_ms.
+        headers = dict(self.headers)
+        headers["max-execution-time"] = str(
+            _execution_budget_ms(
+                self.read_timeout,
+                getattr(self, "server_budget_factor", SERVER_BUDGET_FACTOR),
+                getattr(self, "server_max_execution", SERVER_MAX_EXECUTION_S),
+            )
+        )
+
         for attempt in range(max_retries + 1):
             try:
                 response = requests.post(
                     url=f"{self.base_uri}{self.commit}",
                     auth=(self.usr, self.pwd),
                     data=json.dumps(payload),
-                    headers=self.headers,
+                    headers=headers,
                     timeout=(self.connect_timeout, self.read_timeout),
                 )
             except requests.exceptions.RequestException as e:
@@ -196,6 +275,22 @@ class Neo4jConnect:
 
             if self.rest_return_check(response):
                 return response.json()['results']
+
+            # A statement the server stopped is the same kind of event as a
+            # read that timed out on this side — the work ran long, not wrong —
+            # so it gets the same treatment. Without this the two paths
+            # disagreed: an overrun caught by the client retried and usually
+            # succeeded, while an overrun caught by the server returned False
+            # on the first attempt.
+            if attempt < max_retries and _is_terminated(response):
+                print(
+                    f"Query terminated by the server; retrying in {delay:.0f}s "
+                    f"(attempt {attempt + 2} of {max_retries + 1})..."
+                )
+                time.sleep(delay)
+                delay *= 2
+                continue
+
             return False
 
         return False
@@ -234,13 +329,22 @@ class Neo4jConnect:
         1`` answers the only question being asked.
         """
         cap = getattr(self, "connection_test_timeout", CONNECTION_TEST_TIMEOUT_S)
-        timeout = (min(self.connect_timeout, cap), min(self.read_timeout, cap))
+        read = min(self.read_timeout, cap)
+        timeout = (min(self.connect_timeout, cap), read)
+        probe_headers = dict(headers)
+        probe_headers["max-execution-time"] = str(
+            _execution_budget_ms(
+                read,
+                getattr(self, "server_budget_factor", SERVER_BUDGET_FACTOR),
+                getattr(self, "server_max_execution", SERVER_MAX_EXECUTION_S),
+            )
+        )
         try:
             response = requests.post(
                 url=f"{self.base_uri}{commit_path}",
                 auth=(self.usr, self.pwd),
                 data=json.dumps({'statements': [{'statement': 'RETURN 1'}]}),
-                headers=headers,
+                headers=probe_headers,
                 timeout=timeout,
             )
         except requests.exceptions.RequestException as e:

--- a/src/vfbquery/neo4j_client.py
+++ b/src/vfbquery/neo4j_client.py
@@ -8,9 +8,58 @@ that come with the full vfb_connect package.
 Based on vfb_connect.neo.neo4j_tools.Neo4jConnect
 """
 
+import os
 import requests
 import json
 import time
+
+
+def _env_float(name, default):
+    """Read a float from the environment, ignoring anything unparseable."""
+    try:
+        return float(os.environ.get(name, "") or default)
+    except (TypeError, ValueError):
+        return default
+
+
+#: Seconds to wait for the TCP connect. Short: an unreachable host should fail
+#: immediately rather than sit in the pool.
+CONNECT_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECT_TIMEOUT_S", 10.0)
+
+#: Seconds to wait for the *first byte* of a response. This is the number that
+#: keeps a stalled server from hanging a caller forever.
+#:
+#: ``requests`` defaults to no timeout at all, which means a socket that is open
+#: but silent blocks the calling thread indefinitely. pdb.virtualflybrain.org
+#: does exactly that under load — it accepts the connection and then returns
+#: nothing for minutes — so without this a single blip turns a seven-minute CI
+#: job into one that is still running when the runner's two-hour ceiling kills
+#: it. Raise it with ``VFBQUERY_NEO4J_READ_TIMEOUT_S`` for a genuinely long
+#: analytical query; lower it in CI to fail fast.
+READ_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_READ_TIMEOUT_S", 120.0)
+
+#: How many times a request is retried after a connection-level failure.
+#:
+#: This used to be unbounded: the exception handler slept ten seconds and
+#: re-entered ``commit_list`` recursively, so a server that was down stayed in
+#: that loop until something else killed the process (and grew the Python stack
+#: one frame per attempt while it did). Retrying is still right — the endpoint
+#: does drop the occasional connection — but it has to end.
+MAX_RETRIES = int(_env_float("VFBQUERY_NEO4J_MAX_RETRIES", 3))
+
+#: Seconds to wait before the first retry; doubled for each subsequent one.
+RETRY_BACKOFF_S = _env_float("VFBQUERY_NEO4J_RETRY_BACKOFF_S", 2.0)
+
+#: Ceiling for the connection test run during construction. It only decides
+#: which transaction API the server speaks, so it must not inherit the query
+#: path's patience — see :meth:`Neo4jConnect._probe`.
+CONNECTION_TEST_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S", 15.0)
+
+#: Transaction endpoints, newest first. VFB production speaks the first.
+V4_COMMIT_PATH = "/db/neo4j/tx/commit"
+V4_HEADERS = {'Content-type': 'application/json'}
+V3_COMMIT_PATH = "/db/data/transaction/commit"
+V3_HEADERS = {}
 
 
 def dict_cursor(results):
@@ -40,23 +89,44 @@ class Neo4jConnect:
     :param pwd: password for authentication
     """
     
-    def __init__(self, 
+    def __init__(self,
                  endpoint: str = "http://pdb.virtualflybrain.org",
                  usr: str = "neo4j",
-                 pwd: str = "vfb"):
+                 pwd: str = "vfb",
+                 connect_timeout: float = None,
+                 read_timeout: float = None):
         self.base_uri = endpoint
         self.usr = usr
         self.pwd = pwd
-        self.commit = "/db/neo4j/tx/commit"
-        self.headers = {'Content-type': 'application/json'}
-        
-        # Test connection and fall back to v3 API if needed
-        if not self.test_connection():
+        self.connect_timeout = (CONNECT_TIMEOUT_S if connect_timeout is None
+                                else connect_timeout)
+        self.read_timeout = (READ_TIMEOUT_S if read_timeout is None
+                             else read_timeout)
+        self.max_retries = MAX_RETRIES
+        self.commit = V4_COMMIT_PATH
+        self.headers = dict(V4_HEADERS)
+
+        # Work out which transaction API this server speaks. Only a definitive
+        # negative answer — the server replied, and said no — is grounds for
+        # falling back to v3. A timeout is not an answer: the server being slow
+        # says nothing about which API it speaks, and treating it as a "no" used
+        # to send construction down the v3 path and then raise, so a transient
+        # stall failed the caller outright instead of letting the query's own
+        # bounded retry ride it out.
+        status = self._probe(V4_COMMIT_PATH, V4_HEADERS)
+        if status == "wrong-api":
             print("Falling back to Neo4j v3 connection")
-            self.commit = "/db/data/transaction/commit"
-            self.headers = {}
-            if not self.test_connection():
+            if self._probe(V3_COMMIT_PATH, V3_HEADERS) == "ok":
+                self.commit = V3_COMMIT_PATH
+                self.headers = dict(V3_HEADERS)
+            else:
                 raise Exception("Failed to connect to Neo4j.")
+        elif status == "unreachable":
+            print(
+                f"\033[33mWarning:\033[0m {self.base_uri} did not answer within "
+                f"{min(self.connect_timeout, CONNECTION_TEST_TIMEOUT_S):.0f}s; "
+                "assuming the Neo4j 4+ transaction API and continuing."
+            )
     
     def commit_list(self, statements, return_graphs=False):
         """
@@ -75,24 +145,40 @@ class Neo4jConnect:
                 cstatements.append({'statement': s})
         
         payload = {'statements': cstatements}
-        
-        try:
-            response = requests.post(
-                url=f"{self.base_uri}{self.commit}",
-                auth=(self.usr, self.pwd),
-                data=json.dumps(payload),
-                headers=self.headers
-            )
-        except requests.exceptions.RequestException as e:
-            print(f"\033[31mConnection Error:\033[0m {e}")
-            print("Retrying in 10 seconds...")
-            time.sleep(10)
-            return self.commit_list(statements)
-        
-        if self.rest_return_check(response):
-            return response.json()['results']
-        else:
+
+        max_retries = getattr(self, "max_retries", MAX_RETRIES)
+        delay = RETRY_BACKOFF_S
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.post(
+                    url=f"{self.base_uri}{self.commit}",
+                    auth=(self.usr, self.pwd),
+                    data=json.dumps(payload),
+                    headers=self.headers,
+                    timeout=(self.connect_timeout, self.read_timeout),
+                )
+            except requests.exceptions.RequestException as e:
+                if attempt >= max_retries:
+                    print(f"\033[31mConnection Error:\033[0m {e}")
+                    print(
+                        f"Giving up after {max_retries + 1} attempt(s) "
+                        f"(read timeout {self.read_timeout}s)."
+                    )
+                    return False
+                print(f"\033[31mConnection Error:\033[0m {e}")
+                print(
+                    f"Retrying in {delay:.0f}s "
+                    f"(attempt {attempt + 2} of {max_retries + 1})..."
+                )
+                time.sleep(delay)
+                delay *= 2
+                continue
+
+            if self.rest_return_check(response):
+                return response.json()['results']
             return False
+
+        return False
     
     def rest_return_check(self, response):
         """
@@ -113,10 +199,43 @@ class Neo4jConnect:
             else:
                 return True
     
+    def _probe(self, commit_path, headers):
+        """Ask one transaction endpoint whether it is there and speaks Cypher.
+
+        Returns ``"ok"``, ``"wrong-api"`` (the server answered, and the answer
+        was no) or ``"unreachable"`` (it did not answer in time). Keeping those
+        two failures apart is the whole point: only the first is a reason to
+        try a different endpoint.
+
+        This runs on every construction, so it must not inherit the query
+        path's patience or its retries — with those, a stalled server would
+        cost minutes here, twice, before the caller saw a real query. It also
+        no longer scans for a node (``MATCH (n) RETURN n LIMIT 1``); ``RETURN
+        1`` answers the only question being asked.
+        """
+        timeout = (min(self.connect_timeout, CONNECTION_TEST_TIMEOUT_S),
+                   min(self.read_timeout, CONNECTION_TEST_TIMEOUT_S))
+        try:
+            response = requests.post(
+                url=f"{self.base_uri}{commit_path}",
+                auth=(self.usr, self.pwd),
+                data=json.dumps({'statements': [{'statement': 'RETURN 1'}]}),
+                headers=headers,
+                timeout=timeout,
+            )
+        except requests.exceptions.RequestException as e:
+            print(f"\033[31mConnection Error:\033[0m {e}")
+            return "unreachable"
+
+        if response.status_code != 200:
+            print(f"\033[31mConnection Error:\033[0m "
+                  f"{response.status_code} ({response.reason})")
+            return "wrong-api"
+        try:
+            return "wrong-api" if response.json().get('errors') else "ok"
+        except ValueError:
+            return "wrong-api"
+
     def test_connection(self):
-        """Test neo4j endpoint connection"""
-        statements = ["MATCH (n) RETURN n LIMIT 1"]
-        if self.commit_list(statements):
-            return True
-        else:
-            return False
+        """True if the endpoint this instance is bound to answers ``RETURN 1``."""
+        return self._probe(self.commit, self.headers) == "ok"

--- a/src/vfbquery/neo4j_client.py
+++ b/src/vfbquery/neo4j_client.py
@@ -22,9 +22,19 @@ def _env_float(name, default):
         return default
 
 
+#: Every setting below is a *fallback*, used only when the corresponding
+#: environment variable is unset. They are resolved in :meth:`Neo4jConnect.__init__`,
+#: not at import time, and that distinction matters: ``src/__init__.py`` does
+#: ``from vfbquery import *``, so importing anything under ``src.test`` imports
+#: this module first. Frozen-at-import constants meant a test package could not
+#: set its own timeouts — the values were already read — and the conda job kept
+#: the REPL-tuned defaults no matter what the suite asked for. Reading at
+#: construction also makes the settings genuinely live: change the environment
+#: and the next connection picks it up.
+
 #: Seconds to wait for the TCP connect. Short: an unreachable host should fail
 #: immediately rather than sit in the pool.
-CONNECT_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECT_TIMEOUT_S", 10.0)
+CONNECT_TIMEOUT_S = 10.0
 
 #: Seconds to wait for the *first byte* of a response. This is the number that
 #: keeps a stalled server from hanging a caller forever.
@@ -36,7 +46,7 @@ CONNECT_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECT_TIMEOUT_S", 10.0)
 #: job into one that is still running when the runner's two-hour ceiling kills
 #: it. Raise it with ``VFBQUERY_NEO4J_READ_TIMEOUT_S`` for a genuinely long
 #: analytical query; lower it in CI to fail fast.
-READ_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_READ_TIMEOUT_S", 120.0)
+READ_TIMEOUT_S = 120.0
 
 #: How many times a request is retried after a connection-level failure.
 #:
@@ -45,15 +55,15 @@ READ_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_READ_TIMEOUT_S", 120.0)
 #: that loop until something else killed the process (and grew the Python stack
 #: one frame per attempt while it did). Retrying is still right — the endpoint
 #: does drop the occasional connection — but it has to end.
-MAX_RETRIES = int(_env_float("VFBQUERY_NEO4J_MAX_RETRIES", 3))
+MAX_RETRIES = 3
 
 #: Seconds to wait before the first retry; doubled for each subsequent one.
-RETRY_BACKOFF_S = _env_float("VFBQUERY_NEO4J_RETRY_BACKOFF_S", 2.0)
+RETRY_BACKOFF_S = 2.0
 
 #: Ceiling for the connection test run during construction. It only decides
 #: which transaction API the server speaks, so it must not inherit the query
 #: path's patience — see :meth:`Neo4jConnect._probe`.
-CONNECTION_TEST_TIMEOUT_S = _env_float("VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S", 15.0)
+CONNECTION_TEST_TIMEOUT_S = 15.0
 
 #: Transaction endpoints, newest first. VFB production speaks the first.
 V4_COMMIT_PATH = "/db/neo4j/tx/commit"
@@ -98,11 +108,21 @@ class Neo4jConnect:
         self.base_uri = endpoint
         self.usr = usr
         self.pwd = pwd
-        self.connect_timeout = (CONNECT_TIMEOUT_S if connect_timeout is None
-                                else connect_timeout)
-        self.read_timeout = (READ_TIMEOUT_S if read_timeout is None
-                             else read_timeout)
-        self.max_retries = MAX_RETRIES
+        # Resolved here, not at import time — see the note above the constants.
+        # An explicit argument still wins over the environment.
+        self.connect_timeout = (
+            _env_float("VFBQUERY_NEO4J_CONNECT_TIMEOUT_S", CONNECT_TIMEOUT_S)
+            if connect_timeout is None else connect_timeout
+        )
+        self.read_timeout = (
+            _env_float("VFBQUERY_NEO4J_READ_TIMEOUT_S", READ_TIMEOUT_S)
+            if read_timeout is None else read_timeout
+        )
+        self.max_retries = int(_env_float("VFBQUERY_NEO4J_MAX_RETRIES", MAX_RETRIES))
+        self.retry_backoff = _env_float("VFBQUERY_NEO4J_RETRY_BACKOFF_S", RETRY_BACKOFF_S)
+        self.connection_test_timeout = _env_float(
+            "VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S", CONNECTION_TEST_TIMEOUT_S
+        )
         self.commit = V4_COMMIT_PATH
         self.headers = dict(V4_HEADERS)
 
@@ -124,7 +144,7 @@ class Neo4jConnect:
         elif status == "unreachable":
             print(
                 f"\033[33mWarning:\033[0m {self.base_uri} did not answer within "
-                f"{min(self.connect_timeout, CONNECTION_TEST_TIMEOUT_S):.0f}s; "
+                f"{min(self.connect_timeout, self.connection_test_timeout):.0f}s; "
                 "assuming the Neo4j 4+ transaction API and continuing."
             )
     
@@ -147,7 +167,7 @@ class Neo4jConnect:
         payload = {'statements': cstatements}
 
         max_retries = getattr(self, "max_retries", MAX_RETRIES)
-        delay = RETRY_BACKOFF_S
+        delay = getattr(self, "retry_backoff", RETRY_BACKOFF_S)
         for attempt in range(max_retries + 1):
             try:
                 response = requests.post(
@@ -213,8 +233,8 @@ class Neo4jConnect:
         no longer scans for a node (``MATCH (n) RETURN n LIMIT 1``); ``RETURN
         1`` answers the only question being asked.
         """
-        timeout = (min(self.connect_timeout, CONNECTION_TEST_TIMEOUT_S),
-                   min(self.read_timeout, CONNECTION_TEST_TIMEOUT_S))
+        cap = getattr(self, "connection_test_timeout", CONNECTION_TEST_TIMEOUT_S)
+        timeout = (min(self.connect_timeout, cap), min(self.read_timeout, cap))
         try:
             response = requests.post(
                 url=f"{self.base_uri}{commit_path}",

--- a/src/vfbquery/solr_result_cache.py
+++ b/src/vfbquery/solr_result_cache.py
@@ -1140,7 +1140,29 @@ def with_solr_cache(query_type: str):
                 import inspect
                 func_takes_limit = 'limit' in inspect.signature(func).parameters
 
-                if func_takes_limit:
+                # Computing the full result is only worth doing if we can then
+                # store it. In read-only mode we cannot, so the extra work buys
+                # nothing and is charged entirely to the caller — who asked for
+                # ten rows and gets billed for all of them.
+                #
+                # That is not a theoretical cost. ``expression_overlaps_here``
+                # walks an unbounded ``has_source|SUBCLASSOF|INSTANCEOF`` path
+                # that reaches 100,426 individuals for FBbt_00007228: with the
+                # caller's ``limit=10`` it answers in about six seconds, and at
+                # ``limit=-1`` it does not finish at all. PR checks run with
+                # ``VFBQUERY_CACHE_READONLY=true`` and so can never warm the
+                # cache, which meant every PR paid the uncapped price forever
+                # and one of those runs took production Neo4j down for an hour.
+                honour_callers_limit = (
+                    func_takes_limit and not should_cache and solr_caching_readonly()
+                )
+                if honour_callers_limit:
+                    logger.debug(
+                        f"Cache is read-only; running {query_type}({term_id}) at the "
+                        f"caller's limit={limit} rather than computing the full result"
+                    )
+
+                if func_takes_limit and not honour_callers_limit:
                     # Always compute the full result so we have something
                     # complete to cache. If the caller already asked for
                     # the full result (should_cache=True), this is the same
@@ -1151,8 +1173,15 @@ def with_solr_cache(query_type: str):
                     if _func_takes_offset:
                         full_kwargs['offset'] = 0
                     full_result = _call(*args, **full_kwargs)
+                    result_is_full = True
                 else:
                     full_result = _call(*args, **kwargs)
+                    # Only a full result may be written under the limit=-1
+                    # cache key. A function with no limit parameter always
+                    # returns one; a call made at the caller's own limit does
+                    # not, and caching it would serve a truncated table to
+                    # every later reader as if it were complete.
+                    result_is_full = not honour_callers_limit
 
                 # Validate the full result before caching.
                 full_is_valid = False
@@ -1169,7 +1198,7 @@ def with_solr_cache(query_type: str):
                     else:
                         full_is_valid = True
 
-                if full_is_valid:
+                if full_is_valid and result_is_full:
                     try:
                         full_kwargs_for_cache = kwargs.copy()
                         full_kwargs_for_cache['limit'] = -1
@@ -1182,7 +1211,10 @@ def with_solr_cache(query_type: str):
                 # Return what the caller asked for: full result if
                 # should_cache, else slice the full result to the requested
                 # limit. The slicing mirrors the non-expensive branch below.
-                if should_cache or limit == -1 or full_result is None:
+                # Nothing to slice when the function was already given the
+                # caller's limit — slicing again would apply the offset twice.
+                if (should_cache or limit == -1 or full_result is None
+                        or not result_is_full):
                     result = full_result
                 else:
                     result = full_result

--- a/src/vfbquery/vfb_connectivity.py
+++ b/src/vfbquery/vfb_connectivity.py
@@ -56,9 +56,23 @@ DEFAULT_EXCLUDE_DBS = ["hb", "fafb"]
 MAX_SUBCLASS_IDS = 10000
 
 
+_NC = None
+
+
 def _get_nc():
-    """Get a Neo4jConnect instance for VFB."""
-    return Neo4jConnect()
+    """Get a Neo4jConnect instance for VFB, reusing one per process.
+
+    Constructing ``Neo4jConnect`` runs a connection test to work out whether
+    the server speaks the v4 or v3 transaction API. Returning a fresh instance
+    per call meant that test ran again on every single query — a whole extra
+    round-trip against a shared, and at times very slow, production server,
+    paid before any useful work started. The answer does not change during a
+    process's life, so it is worked out once.
+    """
+    global _NC
+    if _NC is None:
+        _NC = Neo4jConnect()
+    return _NC
 
 
 def _cypher_str(value):
@@ -110,7 +124,8 @@ def _resolve_neuron_type_label(nc, label, notes=None):
             "Check the ID is a valid neuron class (not an anatomy region)."
         )
 
-    # Exact label match
+    # Exact label match. Kept on its own because it is the only step that is an
+    # index seek, and it is what almost every caller hits.
     results = nc.commit_list([
         f"MATCH (n:Class:Neuron) WHERE n.label = {quoted} "
         f"RETURN n.short_form LIMIT 1"
@@ -118,6 +133,16 @@ def _resolve_neuron_type_label(nc, label, notes=None):
     dc = dict_cursor(results)
     if dc:
         return dc[0]["n.short_form"]
+
+    # The tiers below stay as separate statements on purpose. Merging them into
+    # one `OR` was tried, on the reasoning that three sequential round-trips
+    # against an intermittently slow server is three chances to block; measured
+    # against production it was far worse. The single-predicate containment scan
+    # returns in well under a second, while the same scan with the equality and
+    # synonym disjuncts bolted on did not return inside forty seconds on any of
+    # six attempts — the disjunction costs the planner the filter it can push
+    # down. Split, each tier is also short-circuiting: a caller passing a real
+    # label never reaches the scan at all.
 
     # Case-insensitive label fallback
     results = nc.commit_list([


### PR DESCRIPTION
## What this fixes

The Performance Test job stopped finishing inside its 120-minute ceiling. The connectivity Cypher is not the problem — the main query returns 17 rows in 1.94s, and Kenyon cell's 15,994 individuals resolve in 0.85s. The problem is that `pdb.virtualflybrain.org` intermittently accepts a connection and then goes silent for minutes, and the client had no way to notice.

Direct probing of `RETURN 1` against production while writing this: roughly **one request in four to one in six answers**; the rest return nothing inside 30s. That is an infrastructure fault, and it is not fixed here. What is fixed is that VFBquery now fails fast and says so, instead of hanging until the runner kills the job with nothing to show for it.

Three client defects turned a slow upstream into an unbounded one:

1. **No `timeout=` on `requests.post`.** `requests` defaults to no timeout at all, so a silent socket blocks the calling thread indefinitely.
2. **An unbounded recursive retry.** The `RequestException` handler slept 10s and re-entered `commit_list` recursively — no attempt limit, and one more stack frame each time.
3. **A connection test on every construction.** `_get_nc()` built a fresh `Neo4jConnect` per call, and each construction ran `MATCH (n) RETURN n LIMIT 1` before any useful work. PR #82 added a closure query per side on top of resolution and the main query, so each `query_connectivity` drew several more chances at the stall.

Under `pytest -n 8` with the cache off, that is the two-hour job.

## Changes

**`neo4j_client.py`**

- Bounded `timeout=(connect, read)` on every request, with defaults (10s / 120s) overridable per-instance and via `VFBQUERY_NEO4J_CONNECT_TIMEOUT_S` / `VFBQUERY_NEO4J_READ_TIMEOUT_S`.
- Fixed retry count with doubling backoff, replacing the recursion. `VFBQUERY_NEO4J_MAX_RETRIES`, `VFBQUERY_NEO4J_RETRY_BACKOFF_S`.
- New `_probe()` returns three states rather than a bool: `ok`, `wrong-api` (the server answered, and the answer was no) and `unreachable` (it did not answer). Only `wrong-api` is grounds for falling back to the v3 transaction API. Previously a mere timeout sent construction down the v3 path, which also timed out, which raised `Failed to connect to Neo4j` — so a transient stall failed the caller outright instead of letting the query's own retry ride it out.
- The probe is `RETURN 1`, not a node scan, and is capped separately by `VFBQUERY_NEO4J_CONNECTION_TEST_TIMEOUT_S` (15s) so it can never inherit the query path's patience.

**`vfb_connectivity.py`**

- `_get_nc()` memoizes the connection per process. The API version does not change during a process's life; working it out once removes a full round-trip from the front of every query.
- A merge of the label-resolution tiers into one `OR` was tried and **reverted** — it measured far worse, and the measurement is recorded in a code comment so nobody repeats it. Interleaved against production: the split single-predicate containment scan returned in 31.17s and 6.55s; the merged form did not return inside 40s on any of six attempts. The disjunction costs the planner the filter it can push down, and the split tiers short-circuit anyway.

## Cheaper test fixtures

Separately requested: the connectivity tests were pulling result lists far larger than the assertions needed.

- Small classes where size is not the point: `giant fiber neuron` (1 class / 8 individuals) and `peripherally synapsing interneuron` (1 / 6) replace the previous pairs.
- Where a large class **is** the point — the subclass-expansion tests need a parent with no direct instances, so `Kenyon cell` (38 classes / 15,994 individuals) stays — the query now passes `group_by_class=True`. The traversal under test is identical; the table crossing the wire drops from one row per individual pair to one per class pair.
- The three tests that need the same expensive query now share a module-scoped fixture, as do the five that need `list_connectome_datasets()` (4 calls to 1).
- `test_anchor_side_does_not_change_the_answer` moved off Kenyon cell to the small pair — forcing the anchor onto ~16,000 individuals tested nothing extra and cost the most of anything in the file.

## Backstops

- `timeout = 300` in `pyproject.toml` — a per-test ceiling so one stuck test becomes one named failure rather than an unexplained job kill. Needs `pytest-timeout` (added to `requirements.txt`); without it pytest just warns about the unknown option, so it degrades rather than breaks.
- New `src/test/conftest.py` sets fail-fast Neo4j defaults for the suite only (45s reads, 1 retry) via `setdefault`, so a workflow or a developer can still override from the environment. This lives in conftest rather than the workflow because the token available here cannot push to `.github/workflows/`.

## Verification

```
pytest src/test/test_vfb_connectivity.py -m "not integration" -q   ->  1 passed, 16 deselected
pytest --collect-only  (5 connectivity files)                      ->  63 tests collected in 0.04s
```

The integration half cannot be verified green until the upstream stops dropping requests — which is the thing to chase next, and is not a code problem.
