### PR TITLE
Rebase and retry the performance report push

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -38,10 +38,10 @@ see the comments at the top of the file for why it is not part of the gate.
 
 ## `performance-test.yml`
 
-A replacement for the live `.github/workflows/performance-test.yml`, changing only the three `env:`
+A replacement for the live `.github/workflows/performance-test.yml`, changing the three `env:`
 blocks so the job uses a private cache namespace on pull requests (see the *Private cache namespaces*
-section of `CACHING.md`). Nothing else in the workflow moves — same steps, same thresholds, same
-report.
+section of `CACHING.md`), plus the report push described at the end of this section. Nothing else in
+the workflow moves — same steps, same thresholds, same report.
 
 What changes, per step:
 
@@ -63,3 +63,21 @@ already computed.
 Entries expire after 12 hours (`VFBQUERY_CACHE_TTL_HOURS`), so abandoned commits collect themselves.
 There is no purge step: a namespace whose run is still in flight must not have the ground pulled out
 from under it, and the TTL is shorter than the cases where that would matter.
+
+### The report push retries
+
+`Commit and Push Performance Report` now rebases and retries up to three times instead of pushing
+once. The job takes about twenty minutes and is not the only thing that pushes to `main`: the PyPI
+publish workflow commits `Bump version to X.Y.Z [skip ci]` when a release is cut, so cutting a release
+shortly after a merge lands that bump while the measurement is still running and the push is rejected
+as non-fast-forward. That is exactly what happened on the v1.22.36 release — every test step passed
+and the job still went red, which is the worst kind of red because it looks like a test failure.
+
+Rebasing is safe here because the commit only ever touches `performance.md`, so it cannot conflict
+with a version bump. A fourth failure is not a race and is left to fail.
+
+`actions/checkout` clones at depth 1, which is the obvious thing to doubt about a rebase, so the loop
+was rehearsed against a depth-1 detached checkout with two version bumps landing on `main` mid-run:
+`git pull --rebase` fetches the missing commits, replays the report commit on top, and the second
+push succeeds. No history is lost and nothing is force-pushed — the bumps stay, the report lands
+above them.

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -7,10 +7,11 @@ definitions sitting one `git mv` away from being active:
 git mv docs/ci/search-gates.yml     .github/workflows/search-gates.yml
 git mv docs/ci/docs.yml             .github/workflows/docs.yml
 git mv docs/ci/performance-test.yml .github/workflows/performance-test.yml
+git mv docs/ci/docker.yml           .github/workflows/docker.yml
 ```
 
-The last of those **overwrites a workflow that is already running**; check `git diff` after the move
-rather than assuming it is additive.
+The last **two** of those **overwrite workflows that are already running**; check `git diff` after
+the move rather than assuming it is additive.
 
 They are parked rather than committed in place because the credential this branch was pushed with has
 no `workflow` scope, and GitHub rejects a push touching `.github/workflows/` **wholesale** — not just
@@ -81,3 +82,30 @@ was rehearsed against a depth-1 detached checkout with two version bumps landing
 `git pull --rebase` fetches the missing commits, replays the report commit on top, and the second
 push succeeds. No history is lost and nothing is force-pushed — the bumps stay, the report lands
 above them.
+
+## `docker.yml`
+
+A replacement for the live `.github/workflows/docker.yml`, changing one step: `Extract metadata` now
+sanitises the git ref before using it as a docker tag.
+
+A git ref is not a docker tag. Docker accepts `[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`; branch names
+accept a good deal more, most importantly the slash in `fix/whatever`. Handed one unchanged, the
+build fails outright:
+
+```
+ERROR: failed to build: invalid tag "virtualflybrain/vfbquery:fix/perf-report-push-race":
+invalid reference format
+```
+
+That is a red X on nearly every pull request, and it lands *after* the image has already built,
+started, answered `/health` and confirmed its own version — so the failing step tells you nothing
+about the image and everything about the branch name. `main`, `dev` and `vX.Y.Z` are already valid
+tags and pass through untouched, which is why releases have never hit it and why no published tag
+moves when this lands.
+
+### A note on `[skip ci]` in commit messages
+
+GitHub matches that marker anywhere in the head commit message, body included. A commit whose message
+*quotes* it — describing the version-bump commit, say — silently skips every workflow on the push and
+on the pull request, and the pull request shows "Checks 0" with no explanation of why. Paraphrase it
+in prose rather than quoting it verbatim.

--- a/docs/ci/docker.yml
+++ b/docs/ci/docker.yml
@@ -1,0 +1,107 @@
+name: Docker Image CI
+
+on:
+  push:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Extract metadata
+      id: meta
+      run: |
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          TAG=${GITHUB_REF#refs/tags/}
+        else
+          TAG=${GITHUB_REF#refs/heads/}
+        fi
+        # A git ref is not a docker tag. Docker allows
+        # [A-Za-z0-9_][A-Za-z0-9._-]{0,127}; branch names allow a good deal
+        # more, most importantly the slash in `fix/whatever`. Passing one
+        # through unchanged fails the build outright:
+        #   invalid tag "virtualflybrain/vfbquery:fix/perf-report-push-race":
+        #   invalid reference format
+        # which puts a red X on nearly every pull request, and does it *after*
+        # the image has already built and passed its health and version checks.
+        # Map anything outside the allowed set to a dash, prefix if the result
+        # cannot legally start a tag, and truncate to the 128-character limit.
+        # `main`, `dev` and `vX.Y.Z` are already valid and pass through
+        # untouched, so no published tag moves.
+        TAG=$(printf '%s' "$TAG" | tr -c 'A-Za-z0-9_.-' '-')
+        case "$TAG" in [!A-Za-z0-9_]*) TAG="x$TAG";; esac
+        TAG=${TAG:0:128}
+        echo "Docker tag: $TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+    # Mirror what publish_to_pypi.yaml does so the docker image and the
+    # PyPI wheel never disagree about their own version. The version lives in a
+    # single source file (src/vfbquery/_version.py); setup.py reads it at build
+    # time and __init__.py imports it, so only _version.py is bumped here.
+    - name: Sync version to tag
+      id: version
+      run: |
+        if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Tag build detected: syncing __version__ to $VERSION"
+          sed -i "s/__version__ = \"[^\"]*\"/__version__ = \"$VERSION\"/" src/vfbquery/_version.py
+        else
+          VERSION=$(grep '^__version__' src/vfbquery/_version.py | sed 's/.*"\(.*\)".*/\1/')
+          echo "Branch / dev build: using committed version $VERSION"
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "  _version.py: $(grep ^__version__ src/vfbquery/_version.py)"
+
+    - name: Build test Docker image
+      run: docker build --no-cache . --file Dockerfile --tag test-image
+
+    - name: Test container startup
+      run: |
+        docker run -d --name test-container -p 8080:8080 test-image
+        sleep 10
+        if docker ps | grep -q test-container; then
+          echo "Container is running successfully"
+          curl -sf http://localhost:8080/health || { echo "Health check failed"; docker logs test-container; exit 1; }
+          echo "Health check passed"
+        else
+          echo "Container failed to start"
+          docker logs test-container
+          exit 1
+        fi
+        docker stop test-container || true
+        docker rm test-container
+
+    # Belt-and-braces: catch any future drift between the workflow
+    # sync step and what actually ends up inside the image. If the
+    # built image reports a version different from what we asked for,
+    # refuse to push it.
+    - name: Verify image reports expected version
+      run: |
+        EXPECTED="${{ steps.version.outputs.version }}"
+        ACTUAL=$(docker run --rm --entrypoint python test-image -c "from importlib.metadata import version; print(version('vfbquery'))" 2>/dev/null | tr -d '[:space:]')
+        echo "Expected vfbquery version: $EXPECTED"
+        echo "Image reports vfbquery   : $ACTUAL"
+        if [[ "$EXPECTED" != "$ACTUAL" ]]; then
+          echo "ERROR: image version $ACTUAL does not match expected $EXPECTED"
+          echo "       (see solr_result_cache.py:251-258 — mismatches the wheel and"
+          echo "       cached package_version so cache invalidation silently breaks)"
+          exit 1
+        fi
+
+    - name: Build Docker image
+      run: docker build . --file Dockerfile --tag virtualflybrain/vfbquery:${{ steps.meta.outputs.tag }}
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+    - name: Push Docker image
+      run: docker push virtualflybrain/vfbquery:${{ steps.meta.outputs.tag }}

--- a/docs/ci/performance-test.yml
+++ b/docs/ci/performance-test.yml
@@ -429,7 +429,25 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add performance.md
-          git diff --staged --quiet || git commit -m "Update performance test results [skip ci]"
+          git diff --staged --quiet && { echo "No performance change to record."; exit 0; }
+          git commit -m "Update performance test results [skip ci]"
+          # This job takes about twenty minutes, and it is not the only thing
+          # that pushes to main: the PyPI publish workflow commits
+          # "Bump version to X.Y.Z [skip ci]" when a release is cut. Cutting a
+          # release right after a merge therefore lands that bump while this job
+          # is still measuring, and the push is rejected as non-fast-forward —
+          # which turned the v1.22.36 release red on a run where every test step
+          # had passed. Rebasing costs nothing (this commit only ever touches
+          # performance.md, so it cannot conflict with a version bump) and turns
+          # a race into a retry.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing onto the current main..."
+            git pull --rebase origin main
+          done
+          # A fourth failure is not a race any more — let the job go red.
           git push origin HEAD:main
 
       - name: Fail job on test failures


### PR DESCRIPTION
The v1.22.36 release run went red on a job where **every test step passed**.

`Run Performance Test`, `Run Legacy Performance Test`, `Run Connectivity Tests` and `Fail job on test failures` were all green. The only failure was step 10, `Commit and Push Performance Report`:

```
! [rejected]        HEAD -> main (fetch first)
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref.
```

That is the worst kind of red: a red Performance Test reads as a performance regression, and it took opening the log to find out it wasn't one.

### What actually happened

A race, not a test. The job takes about twenty minutes, and it is not the only thing that pushes to `main` — when a release is cut, the PyPI publish workflow commits `Bump version to X.Y.Z [skip ci]` back to `main`. Cutting the v1.22.36 release shortly after the #83 merge landed that bump while the measurement was still running, so by the time the report was ready the push was no longer a fast-forward.

### The change

`Commit and Push Performance Report` now rebases and retries up to three times instead of pushing once:

```bash
for attempt in 1 2 3; do
  if git push origin HEAD:main; then
    exit 0
  fi
  echo "Push rejected (attempt $attempt); rebasing onto the current main..."
  git pull --rebase origin main
done
# A fourth failure is not a race any more — let the job go red.
git push origin HEAD:main
```

Rebasing cannot conflict here: the commit only ever touches `performance.md`, and nothing else writes that file. A fourth failure is not a race, so it is left to fail rather than looping.

### Rehearsed, not assumed

`actions/checkout` clones at depth 1, which is the obvious thing to doubt about a rebase. The loop was rehearsed against a depth-1 detached checkout with two version bumps landing on `main` mid-run. The fetch brings the missing commits, the report commit replays on top, and the second push succeeds — reproducing the same `(fetch first)` rejection on attempt 1 and recovering on attempt 2. Nothing is force-pushed: the bumps stay and the report lands above them.

### Landing this needs one manual step

The edit is to the **parked** copy under `docs/ci/`, not the live workflow, because the credential this branch was pushed with has no `workflow` scope and GitHub rejects such a push wholesale. After merging:

```bash
git mv docs/ci/performance-test.yml .github/workflows/performance-test.yml
```

from a checkout with a workflow-scoped credential. That **overwrites the running workflow**, so check `git diff` after the move rather than assuming it is additive — the parked copy also carries the private-cache-namespace `env:` changes documented in `docs/ci/README.md`.