### PR TITLE
Surface a DataSet's own licence in term info

### DIFF
--- a/src/test/test_term_info_parity.py
+++ b/src/test/test_term_info_parity.py
@@ -151,6 +151,35 @@ class TermInfoParityTest(unittest.TestCase):
                         "License term_info failed validity check")
         self.assertIn("License", result.get("SuperTypes", []))
 
+    # --- Gap E: a term's own licence (`license`) must reach Licenses{} -----
+    # DataSet term info returns has_license on the term itself as `license`
+    # (QueryLibrary.dataset_term_info), not as `dataset_license`. The
+    # serialiser only read `dataset_license`, so every dataset page rendered
+    # without a License row even though the edge was in the KB.
+    def test_dataset_own_license_reaches_licenses(self):
+        ti = self._parse("Cachero2010")
+        licenses = ti.get("Licenses", {})
+        self.assertTrue(licenses, "DataSet own licence dropped from Licenses{}")
+        lic = licenses[0]
+        self.assertTrue(lic.get("short_form", "").startswith("VFBlicense"),
+                        f"unexpected licence short_form: {lic.get('short_form')}")
+        self.assertTrue(lic.get("label"), "licence label missing")
+        self.assertTrue(lic.get("iri"), "licence iri missing")
+
+    def test_dataset_own_license_has_no_self_source(self):
+        # The dataset is its own source, so leave source empty rather than
+        # rendering a Source row that links back to the same page.
+        lic = self._parse("Cachero2010").get("Licenses", {})[0]
+        self.assertEqual("", lic.get("source", ""))
+        self.assertEqual("", lic.get("source_iri", ""))
+
+    def test_dataset_license_still_attributes_source_on_images(self):
+        # The dataset_license path is unchanged: an image/template still gets
+        # its licence via the dataset it came from, with that dataset as source.
+        licenses = self._parse("VFB_00101567").get("Licenses", {})
+        self.assertTrue(licenses, "template lost its inherited licence")
+        self.assertTrue(licenses[0].get("source"), "inherited licence lost its source")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/vfbquery/vfb_queries.py
+++ b/src/vfbquery/vfb_queries.py
@@ -963,9 +963,31 @@ def term_info_parse_object(results, short_form):
                 record['icon'] = dataset_license.license.icon
                 record['source_iri'] = dataset_license.dataset.core.iri
                 record['source'] = dataset_license.dataset.core.label
-                licenses[idx] = record 
+                licenses[idx] = record
             termInfo["Licenses"] = licenses
-              
+        elif vfbTerm.license and len(vfbTerm.license) > 0:
+            # Terms that carry a licence directly rather than inheriting one
+            # from the dataset they came from. DataSet term info (see
+            # QueryLibrary.dataset_term_info) returns has_license on the term
+            # itself as `license`, with no `dataset_license`, so without this
+            # branch every dataset page loses its License row.
+            # Mirrors the fallback in term_info_queries.VFBTerm.get_license()
+            # and the legacy Java serialiser (VFBProcessTermInfoJson.getLicense).
+            licenses = {}
+            for idx, lcns in enumerate(vfbTerm.license):
+                record = {}
+                record['iri'] = lcns.core.iri
+                record['short_form'] = lcns.core.short_form
+                record['label'] = lcns.core.label
+                record['icon'] = lcns.icon
+                # No source dataset to attribute: the term is its own source,
+                # and an empty source keeps the panel from rendering a Source
+                # row that links back to the page you are already on.
+                record['source_iri'] = ''
+                record['source'] = ''
+                licenses[idx] = record
+            termInfo["Licenses"] = licenses
+
         if vfbTerm.template_channel and vfbTerm.template_channel.channel.short_form:
             termInfo["IsTemplate"] = True
             images = {}

--- a/src/vfbquery/vfb_queries.py
+++ b/src/vfbquery/vfb_queries.py
@@ -973,6 +973,9 @@ def term_info_parse_object(results, short_form):
             # branch every dataset page loses its License row.
             # Mirrors the fallback in term_info_queries.VFBTerm.get_license()
             # and the legacy Java serialiser (VFBProcessTermInfoJson.getLicense).
+            # Deliberately elif, not a merge: the query library populates one or
+            # the other per term type, and if a term ever carried both, the
+            # inherited dataset licence wins -- same precedence as get_license().
             licenses = {}
             for idx, lcns in enumerate(vfbTerm.license):
                 record = {}


### PR DESCRIPTION
## Problem

Every DataSet page in v2 renders without a License row, e.g.
https://v2.virtualflybrain.org/org.geppetto.frontend/geppetto?id=Berg2025

The licence is in the KB — `(:DataSet {short_form:'Berg2025'})-[:has_license]->(:License {short_form:'VFBlicense_CC_BY_4_0'})` — and it shows correctly in the `AllDatasets` results table. It is lost in term-info serialisation.

## Cause

`QueryLibrary.dataset_term_info` (VFB_json_schema) uses the `license()` clause, so a dataset's licence comes back in `license`. Images and templates use `dataSet_license()` and come back in `dataset_license`.

`term_info_parse_object` only ever read `dataset_license`, so DataSet terms serialised as `"Licenses": {}`. Downstream, `VFBProcessTermInfoVFBqueryJson.licenseList()` builds the Source + License block from `Licenses{}` alone, so with an empty dict no License row is added.

The fallback exists everywhere else — `term_info_queries.VFBTerm.get_license()` has `elif self.license:`, and the legacy `VFBProcessTermInfoJson.getLicense()` has the same `else if`. Only this serialiser lost it, so the row disappeared when v2 moved onto the VFBquery term-info path.

## Fix

Add the missing branch. `source`/`source_iri` are left empty: the dataset is its own source, and an empty source stops the panel rendering a Source row that links back to the page you are already on. No Java or client change needed — the `License` slot is already in `VFBMain.js`'s ordered field list.

## Verification

Parsed against live SOLR after the change:

| Dataset | Licence |
|---|---|
| Berg2025 | CC-BY 4.0 |
| Bates2025 | CC-BY 4.0 |
| Dorkenwald2023 | CC-BY-NC 4.0 |
| Cachero2010 | CC-BY-SA 4.0 |

Three tests added to `test_term_info_parity.py` as Gap E, alongside the gaps this serialiser has already been reconciled against. The two dataset tests fail on `main` and pass here; the third asserts the `dataset_license` path is unchanged (JRC2018U keeps both its licence and its source attribution).

Note: `test_individual_synonyms_present` in that file already fails on `main` and is untouched by this change.
